### PR TITLE
Add architecture user stories

### DIFF
--- a/design/units.md
+++ b/design/units.md
@@ -5,4 +5,6 @@ Units are discrete pieces of work: features, components, refactors, rewrites, et
 For creating new units, use the [unit template](units/template/README.md).
 
 ## MVP
-- [Architecture](units/architecture/bsd.md)
+- [Architecture - BSD](units/architecture/bsd.md)
+- [Architecture - FSD](units/architecture/fsd.md)
+- [Architecture - User Stories](units/architecture/user_stories.md)

--- a/design/units/architecture/user_stories.md
+++ b/design/units/architecture/user_stories.md
@@ -1,0 +1,103 @@
+# User Stories
+
+## As a developer, I want to run the ACE Framework locally with minimal setup so that I can start developing quickly.
+
+**Priority:** Must Have
+
+### Scenarios
+
+**Scenario 1: First-time local setup**
+- Given I have Docker installed on my machine
+- When I run `docker compose up`
+- Then all services start successfully
+- And I can access the web UI at `http://localhost:8000`
+
+**Scenario 2: Quick restart**
+- Given I have previously run the system
+- When I make code changes
+- Then the system hot-reloads automatically
+
+---
+
+## As a developer, I want clear component boundaries so that I can work on different parts independently.
+
+**Priority:** Must Have
+
+### Scenarios
+
+**Scenario 1: Independent frontend development**
+- Given the API and Frontend are separate components
+- When I modify frontend code
+- Then I don't need to rebuild the cognitive engine
+
+**Scenario 2: Independent cognitive engine development**
+- Given the cognitive engine has clear interfaces
+- When I modify the ACE layer implementations
+- Then I don't need to modify the API or persistence layers
+
+---
+
+## As a user, I want a web interface to interact with the ACE Framework so that I can visualize agent behavior.
+
+**Priority:** Must Have
+
+### Scenarios
+
+**Scenario 1: Submit a task**
+- Given the web UI is loaded
+- When I enter a task description
+- Then I can see real-time progress
+- And I receive the final result
+
+**Scenario 2: View agent reasoning**
+- Given I have submitted a task
+- When the task is processing
+- Then I can see the agent's reasoning steps
+
+---
+
+## As an operator, I want to scale the system to multiple ACE agents so that I can handle increased load.
+
+**Priority:** Should Have
+
+### Scenarios
+
+**Scenario 1: Scale cognitive engines**
+- Given the system is running in Kubernetes
+- When I increase the replica count
+- Then additional ACE pods start
+- And requests are distributed across pods
+
+**Scenario 2: Agent swarm communication**
+- Given multiple ACE pods are running
+- When agents need to collaborate
+- Then they can communicate via NATS
+- And maintain loose coupling
+
+---
+
+## As an operator, I want the system to persist data so that I don't lose state on restart.
+
+**Priority:** Must Have
+
+### Scenarios
+
+**Scenario 1: Persistent storage**
+- Given PostgreSQL is configured
+- When the system restarts
+- Then previous agent state is preserved
+- And conversation history is available
+
+---
+
+## As a developer, I want to extend the ACE layers so that I can implement custom cognitive behaviors.
+
+**Priority:** Should Have
+
+### Scenarios
+
+**Scenario 1: Custom layer implementation**
+- Given I need to modify the moral reasoning
+- When I implement a custom layer
+- Then it integrates with the existing framework
+- And other layers remain unchanged


### PR DESCRIPTION
## Summary
Add user stories for the Architecture unit.

## Changes
- Created `design/units/architecture/user_stories.md` with 6 priority user stories:
  1. **Local Setup**: Run ACE Framework locally with minimal setup (Docker Compose)
  2. **Component Boundaries**: Work on different parts independently
  3. **Web UI**: Interact with and visualize agent behavior
  4. **Scaling**: Scale to multiple ACE agents in Kubernetes
  5. **Persistent Storage**: Preserve data across restarts
  6. **Extendable Layers**: Implement custom cognitive behaviors

Each story includes Priority and Gherkin-format scenarios (Given/When/Then).

## Updated Files
- `design/units/architecture/user_stories.md` (new)
- `design/units.md` (added links to all architecture docs)
