### PR TITLE
Add Frontend unit BSD

### DIFF
--- a/design/units/README.md
+++ b/design/units/README.md
@@ -8,3 +8,4 @@ For creating new units, use the [unit template](template/README.md).
 
 - [Architecture](architecture/README.md)
 - [Core Infrastructure](core-infra/README.md)
+- [Frontend](frontend/README.md)

--- a/design/units/frontend/README.md
+++ b/design/units/frontend/README.md
@@ -1,0 +1,3 @@
+# Frontend
+
+- [BSD](bsd.md)

--- a/design/units/frontend/bsd.md
+++ b/design/units/frontend/bsd.md
@@ -1,0 +1,57 @@
+# Business Specification Document
+
+## Unit Name
+Frontend
+
+## Problem Statement
+The ACE Framework lacks a user interface for interacting with agents. Without a frontend:
+- Users cannot create or manage agents
+- Real-time thought traces cannot be visualized
+- Memory exploration requires API calls
+- Tool configuration requires direct database or API access
+
+## Solution
+Build a user-facing SvelteKit frontend providing:
+- User authentication (register, login)
+- Agent management (create, configure, start, stop, delete)
+- Real-time chat interface with WebSocket
+- Live thought trace visualization
+- Memory browser and search
+
+## In Scope
+- User authentication UI (login/register forms)
+- Agent CRUD UI
+- Agent lifecycle controls (start/stop)
+- Real-time chat interface
+- Thought trace viewer (live streaming)
+- Memory browser (tree view + tag search)
+- Responsive design for desktop browsers
+
+## Out of Scope
+- Admin dashboard
+- Mobile-optimized UI
+- Agent marketplace
+- Billing/subscription
+- Complex data visualizations
+
+## Value Proposition
+A user-facing frontend enables:
+- **Accessibility**: Non-technical users can use ACE
+- **Debugging**: Visual thought traces help understand agent behavior
+- **Engagement**: Chat interface for natural interaction
+
+## Success Criteria
+| Criterion | Metric | Target |
+|-----------|--------|--------|
+| Auth UI | Login + register | Functional |
+| Agent CRUD | Full management | All operations work |
+| Real-time chat | Send/receive messages | WebSocket works |
+| Thought viewer | Live thought streaming | <100ms latency |
+| Memory browser | View + search | Tags + tree view |
+
+## Key Requirements
+- **SvelteKit**: Full-stack framework
+- **TypeScript**: Type-safe code
+- **WebSocket**: Real-time updates
+- **JWT Auth**: Integrates with API auth
+- **Responsive**: Desktop-first


### PR DESCRIPTION
## Summary

Add Frontend unit with Business Specification Document (BSD).

## Problem
The ACE Framework lacks a user interface for interacting with agents:
- Users cannot create or manage agents
- Real-time thought traces cannot be visualized
- Memory exploration requires API calls
- Tool configuration requires direct database or API access

## Solution
Build a user-facing SvelteKit frontend providing:
- User authentication (register, login)
- Agent management (create, configure, start, stop, delete)
- Real-time chat interface with WebSocket
- Live thought trace visualization
- Memory browser and search

## Changes
- Created `design/units/frontend/` directory
- Added `bsd.md` with full business specification

## In Scope
- User authentication UI
- Agent CRUD
- Agent lifecycle controls
- Real-time chat
- Thought trace viewer
- Memory browser
- Desktop-first responsive design

## Out of Scope
- Admin dashboard
- Mobile UI
- Agent marketplace
- Billing