### PR TITLE
docs: add core-infra BSD for development environment setup

### DIFF
--- a/design/units/README.md
+++ b/design/units/README.md
@@ -7,3 +7,4 @@ For creating new units, use the [unit template](template/README.md).
 ## Foundation
 
 - [Architecture](architecture/README.md)
+- [Core Infrastructure](core-infra/README.md)

--- a/design/units/core-infra/README.md
+++ b/design/units/core-infra/README.md
@@ -1,0 +1,3 @@
+# Core Infrastructure
+
+- [BSD](bsd.md)

--- a/design/units/core-infra/bsd.md
+++ b/design/units/core-infra/bsd.md
@@ -1,0 +1,52 @@
+# Business Specification Document
+
+## Unit Name
+Core Infrastructure - Development Environment Setup
+
+## Problem Statement
+The project lacks a standardized, containerized development environment. Developers must manually install and configure Go, Node.js, PostgreSQL, NATS, and other dependencies on their host machines, leading to:
+- Inconsistent environments across team members
+- Difficulty onboarding new developers
+- Version conflicts between projects
+- Complex setup instructions
+
+## Solution
+Establish a complete containerized development environment using Docker/Podman that provides:
+- Go backend running in a container with hot reloading
+- SvelteKit frontend running in a container with hot reloading
+- PostgreSQL database container
+- NATS messaging server container
+- All services orchestrated via Docker Compose
+
+## In Scope
+- Docker Compose configuration for all services
+- Go backend container with hot reloading (air or equivalent)
+- SvelteKit frontend container with hot reloading (Vite)
+- PostgreSQL database container
+- NATS server container
+- Development workflow documentation
+- Makefile or scripts for common operations
+
+## Out of Scope
+- Production deployment configurations
+- Database migrations or schema
+- Application functionality (nothing needs to "work")
+- Authentication or authorization
+- CI/CD pipelines
+- Monitoring or observability setup
+
+## Value Proposition
+- Developers can start developing in minutes without installing any tools locally
+- Consistent environment across all team members
+- Easy cleanup and recreation of environment
+- Standardized development workflow
+
+## Success Criteria
+| Criterion | Metric | Target |
+|-----------|--------|--------|
+| All services start | `docker compose up` completes without errors | All 4 containers running |
+| Backend hot reload | Source code changes reflect in <5 seconds | < 5 seconds |
+| Frontend hot reload | Source code changes reflect in <5 seconds | < 5 seconds |
+| Database accessible | Can connect to PostgreSQL from backend | Connection successful |
+| NATS accessible | Can connect to NATS from backend | Connection successful |
+| Clean startup | Fresh clone + docker compose up works | Complete in <10 minutes |


### PR DESCRIPTION
## Summary
Create the Core Infrastructure unit with a BSD focused on containerized development environment setup.

## Changes
- Add Core Infrastructure unit under `design/units/core-infra/`
- BSD defines scope for Docker/Podman-based dev environment
- Includes: Go backend with hot reloading, SvelteKit frontend with hot reloading, PostgreSQL, NATS
- Success criteria: services start, hot reload works, database/NATS accessible

## Test Results
N/A - This is a documentation-only change