### PR TITLE
docs: Mark messaging-paradigm architecture as merged

### DIFF
--- a/design/units/messaging-paradigm/README.md
+++ b/design/units/messaging-paradigm/README.md
@@ -19,4 +19,4 @@ Establish communication contracts between all services using NATS.
 - [x] User Stories - Merged
 - [x] Research - Merged
 - [x] FSD - Merged
-- [x] Architecture - In Review
+- [x] Architecture - Merged


### PR DESCRIPTION
Trivial fix to update the README status.

Closes #messaging-paradigm