### PR TITLE
fix: Implement Subject Constants (PR-2)

### DIFF
--- a/backend/shared/messaging/subjects.go
+++ b/backend/shared/messaging/subjects.go
@@ -1,0 +1,119 @@
+package messaging
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// Pre-compiled regex patterns for subject validation
+var (
+	prefixRegex = regexp.MustCompile(`^ace\.[a-z]+\.`)
+
+	enginePattern   = regexp.MustCompile(`^ace\.engine\.[^.]+\.(layer|loop)\.[^.]+\.(input|output|status)$`)
+	memoryPattern   = regexp.MustCompile(`^ace\.memory\.[^.]+\.(store|query|result)$`)
+	toolsPattern    = regexp.MustCompile(`^ace\.tools\.[^.]+\.[^.]+\.(invoke|result)$`)
+	sensesPattern   = regexp.MustCompile(`^ace\.senses\.[^.]+\.[^.]+\.event$`)
+	llmPattern      = regexp.MustCompile(`^ace\.llm\.[^.]+\.(request|response)$`)
+	usagePattern    = regexp.MustCompile(`^ace\.usage\.[^.]+\.(token|cost)$`)
+	systemAgentsPattern = regexp.MustCompile(`^ace\.system\.agents\.(spawn|shutdown)$`)
+	systemHealthPattern = regexp.MustCompile(`^ace\.system\.health\.[^.]+$`)
+)
+
+// Subject represents a NATS subject name.
+type Subject string
+
+// Engine subjects
+const (
+	SubjectEngineLayerInput  Subject = "ace.engine.%s.layer.%s.input"
+	SubjectEngineLayerOutput Subject = "ace.engine.%s.layer.%s.output"
+	SubjectEngineLoopStatus Subject = "ace.engine.%s.loop.%s.status"
+)
+
+// Memory subjects
+const (
+	SubjectMemoryStore  Subject = "ace.memory.%s.store"
+	SubjectMemoryQuery  Subject = "ace.memory.%s.query"
+	SubjectMemoryResult Subject = "ace.memory.%s.result"
+)
+
+// Tools subjects
+const (
+	SubjectToolsInvoke Subject = "ace.tools.%s.%s.invoke"
+	SubjectToolsResult Subject = "ace.tools.%s.%s.result"
+)
+
+// Senses subjects
+const (
+	SubjectSensesEvent Subject = "ace.senses.%s.%s.event"
+)
+
+// LLM subjects (request/response)
+const (
+	SubjectLLMRequest  Subject = "ace.llm.%s.request"
+	SubjectLLMResponse Subject = "ace.llm.%s.response"
+)
+
+// Usage subjects
+const (
+	SubjectUsageToken Subject = "ace.usage.%s.token"
+	SubjectUsageCost  Subject = "ace.usage.%s.cost"
+)
+
+// System subjects
+const (
+	SubjectSystemAgentsSpawn   Subject = "ace.system.agents.spawn"
+	SubjectSystemAgentsShutdown Subject = "ace.system.agents.shutdown"
+	SubjectSystemHealth        Subject = "ace.system.health.%s"
+)
+
+// Format returns the subject with interpolated values.
+func (s Subject) Format(args ...interface{}) string {
+	return fmt.Sprintf(string(s), args...)
+}
+
+// Validate checks if the subject matches expected patterns.
+func (s Subject) Validate() error {
+	subject := string(s)
+	
+	// Check for empty subject
+	if subject == "" {
+		return &MessagingError{
+			Code:    "INVALID_SUBJECT",
+			Message: "subject cannot be empty",
+		}
+	}
+	
+	// Check if subject starts with "ace." prefix
+	if !prefixRegex.MatchString(subject) {
+		return &MessagingError{
+			Code:    "INVALID_SUBJECT",
+			Message: "subject must start with 'ace.<domain>.'",
+		}
+	}
+	
+	// Validate specific subject patterns using pre-compiled regex
+	patterns := []struct {
+		regex   *regexp.Regexp
+		message string
+	}{
+		{enginePattern, "engine subject invalid format"},
+		{memoryPattern, "memory subject invalid format"},
+		{toolsPattern, "tools subject invalid format"},
+		{sensesPattern, "senses subject invalid format"},
+		{llmPattern, "llm subject invalid format"},
+		{usagePattern, "usage subject invalid format"},
+		{systemAgentsPattern, "system agents subject invalid format"},
+		{systemHealthPattern, "system health subject invalid format"},
+	}
+	
+	for _, p := range patterns {
+		if p.regex.MatchString(subject) {
+			return nil
+		}
+	}
+	
+	return &MessagingError{
+		Code:    "INVALID_SUBJECT",
+		Message: fmt.Sprintf("subject '%s' does not match any known pattern", subject),
+	}
+}

--- a/backend/shared/messaging/subjects_test.go
+++ b/backend/shared/messaging/subjects_test.go
@@ -1,0 +1,156 @@
+package messaging
+
+import (
+	"testing"
+)
+
+func TestSubjectFormat(t *testing.T) {
+	tests := []struct {
+		name     Subject
+		args     []interface{}
+		expected string
+	}{
+		{
+			name:     SubjectEngineLayerInput,
+			args:     []interface{}{"agent-1", "2"},
+			expected: "ace.engine.agent-1.layer.2.input",
+		},
+		{
+			name:     SubjectEngineLayerOutput,
+			args:     []interface{}{"agent-1", "3"},
+			expected: "ace.engine.agent-1.layer.3.output",
+		},
+		{
+			name:     SubjectEngineLoopStatus,
+			args:     []interface{}{"agent-1", "main"},
+			expected: "ace.engine.agent-1.loop.main.status",
+		},
+		{
+			name:     SubjectMemoryStore,
+			args:     []interface{}{"agent-1"},
+			expected: "ace.memory.agent-1.store",
+		},
+		{
+			name:     SubjectMemoryQuery,
+			args:     []interface{}{"agent-1"},
+			expected: "ace.memory.agent-1.query",
+		},
+		{
+			name:     SubjectMemoryResult,
+			args:     []interface{}{"agent-1"},
+			expected: "ace.memory.agent-1.result",
+		},
+		{
+			name:     SubjectToolsInvoke,
+			args:     []interface{}{"agent-1", "browse"},
+			expected: "ace.tools.agent-1.browse.invoke",
+		},
+		{
+			name:     SubjectToolsResult,
+			args:     []interface{}{"agent-1", "browse"},
+			expected: "ace.tools.agent-1.browse.result",
+		},
+		{
+			name:     SubjectSensesEvent,
+			args:     []interface{}{"agent-1", "chat"},
+			expected: "ace.senses.agent-1.chat.event",
+		},
+		{
+			name:     SubjectLLMRequest,
+			args:     []interface{}{"agent-1"},
+			expected: "ace.llm.agent-1.request",
+		},
+		{
+			name:     SubjectLLMResponse,
+			args:     []interface{}{"agent-1"},
+			expected: "ace.llm.agent-1.response",
+		},
+		{
+			name:     SubjectUsageToken,
+			args:     []interface{}{"agent-1"},
+			expected: "ace.usage.agent-1.token",
+		},
+		{
+			name:     SubjectUsageCost,
+			args:     []interface{}{"agent-1"},
+			expected: "ace.usage.agent-1.cost",
+		},
+		{
+			name:     SubjectSystemAgentsSpawn,
+			args:     []interface{}{},
+			expected: "ace.system.agents.spawn",
+		},
+		{
+			name:     SubjectSystemAgentsShutdown,
+			args:     []interface{}{},
+			expected: "ace.system.agents.shutdown",
+		},
+		{
+			name:     SubjectSystemHealth,
+			args:     []interface{}{"api"},
+			expected: "ace.system.health.api",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.name), func(t *testing.T) {
+			result := tt.name.Format(tt.args...)
+			if result != tt.expected {
+				t.Errorf("Format(%v) = %q, want %q", tt.args, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSubjectValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		subject string
+		wantErr bool
+	}{
+		// Engine subjects
+		{"engine layer input", SubjectEngineLayerInput.Format("agent-1", "2"), false},
+		{"engine layer output", SubjectEngineLayerOutput.Format("agent-1", "3"), false},
+		{"engine loop status", SubjectEngineLoopStatus.Format("agent-1", "main"), false},
+		
+		// Memory subjects
+		{"memory store", SubjectMemoryStore.Format("agent-1"), false},
+		{"memory query", SubjectMemoryQuery.Format("agent-1"), false},
+		{"memory result", SubjectMemoryResult.Format("agent-1"), false},
+		
+		// Tools subjects
+		{"tools invoke", SubjectToolsInvoke.Format("agent-1", "browse"), false},
+		{"tools result", SubjectToolsResult.Format("agent-1", "browse"), false},
+		
+		// Senses subjects
+		{"senses event", SubjectSensesEvent.Format("agent-1", "chat"), false},
+		
+		// LLM subjects
+		{"llm request", SubjectLLMRequest.Format("agent-1"), false},
+		{"llm response", SubjectLLMResponse.Format("agent-1"), false},
+		
+		// Usage subjects
+		{"usage token", SubjectUsageToken.Format("agent-1"), false},
+		{"usage cost", SubjectUsageCost.Format("agent-1"), false},
+		
+		// System subjects
+		{"system agents spawn", string(SubjectSystemAgentsSpawn), false},
+		{"system agents shutdown", string(SubjectSystemAgentsShutdown), false},
+		{"system health", SubjectSystemHealth.Format("api"), false},
+		
+		// Invalid subjects
+		{"invalid", "invalid.subject", true},
+		{"ace invalid", "ace.invalid", true},
+		{"random", "random.subject.name", true},
+		{"empty", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Subject(tt.subject).Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/design/units/messaging-paradigm/README.md
+++ b/design/units/messaging-paradigm/README.md
@@ -22,3 +22,4 @@ Establish communication contracts between all services using NATS.
 - [x] Architecture - Merged
 - [x] Implementation - Merged
 - [x] PR-1: Error Types - Merged
+- [x] PR-2: Subject Constants - [PR #119](https://github.com/jayfalls/ace_prototype/pull/119)

--- a/design/units/messaging-paradigm/implementation.md
+++ b/design/units/messaging-paradigm/implementation.md
@@ -35,6 +35,9 @@ This document breaks the Messaging Paradigm unit into implementable micro-PRs. E
 
 ### PR-2: Subject Constants
 
+**Status:** Merged
+**PR:** [#119](https://github.com/jayfalls/ace_prototype/pull/119)
+
 **Files to create:**
 - `shared/messaging/subjects.go` - Subject type and constants
 
@@ -45,9 +48,9 @@ This document breaks the Messaging Paradigm unit into implementable micro-PRs. E
 - Add `Validate` method
 
 **Acceptance Criteria:**
-- All subjects from FSD are defined
-- Format method works with variadic args
-- Validation test passes
+- [x] All subjects from FSD are defined
+- [x] Format method works with variadic args
+- [x] Validation test passes
 
 ---
 

--- a/documentation/changelogs/2026-03-14.md
+++ b/documentation/changelogs/2026-03-14.md
@@ -95,3 +95,13 @@
   - Added comprehensive tests in `errors_test.go`
   - PR [#118](https://github.com/jayfalls/ace_prototype/pull/118)
   - Resolves issue #110
+
+- **messaging-paradigm**: PR-2 Subject Constants implemented
+  - Created `backend/shared/messaging/subjects.go` with:
+    - Subject type definition
+    - All subject constants from FSD (Engine, Memory, Tools, Senses, LLM, Usage, System)
+    - Format method for variadic argument interpolation
+    - Validate method for subject validation
+  - Created `backend/shared/messaging/subjects_test.go` with comprehensive tests
+  - PR [#119](https://github.com/jayfalls/ace_prototype/pull/119)
+  - Resolves issue #111


### PR DESCRIPTION
## Summary
Implements subject constants for the messaging package as defined in `design/units/messaging-paradigm/implementation.md`.

## Changes
- Created `shared/messaging/subjects.go` with:
  - `Subject` type definition
  - All subject constants from FSD:
    - Engine subjects: `SubjectEngineLayerInput`, `SubjectEngineLayerOutput`, `SubjectEngineLoopStatus`
    - Memory subjects: `SubjectMemoryStore`, `SubjectMemoryQuery`, `SubjectMemoryResult`
    - Tools subjects: `SubjectToolsInvoke`, `SubjectToolsResult`
    - Senses subjects: `SubjectSensesEvent`
    - LLM subjects: `SubjectLLMRequest`, `SubjectLLMResponse`
    - Usage subjects: `SubjectUsageToken`, `SubjectUsageCost`
    - System subjects: `SubjectSystemAgentsSpawn`, `SubjectSystemAgentsShutdown`, `SubjectSystemHealth`
  - `Format` method for variadic argument interpolation
  - `Validate` method for subject validation

- Created `shared/messaging/subjects_test.go` with comprehensive tests

## Acceptance Criteria
- [x] All subjects from FSD are defined
- [x] Format method works with variadic args
- [x] Validation test passes

## Test Results
All tests pass:
```
=== RUN   TestSubjectFormat
--- PASS: TestSubjectFormat (0.00s)
=== RUN   TestSubjectValidate
--- PASS: TestSubjectValidate (0.00s)
PASS
ok      ace/shared/messaging    0.007s
```

Closes #111