### PR TITLE
fix: add triggers to verify skill for /verify command activation

### DIFF
--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: verify
 description: This skill should be used when the user sends a message starting with "/verify" to request confirmation that the agent has completed all required startup and setup steps before beginning any work. Use this skill to verify the agent is properly configured.
+triggers:
+  - /verify
+  - verify
 ---
 
 # Verify Skill


### PR DESCRIPTION
## Summary
The verify skill was missing the `triggers` configuration in its YAML frontmatter, which prevented it from being activated when users sent `/verify` commands.

## Fix
Added the missing triggers configuration:
```yaml
triggers:
  - /verify
  - verify
```

## Test Results
All pre-commit quality gates passed:
- Go build verification: PASS
- SQLC generate validation: PASS
- Go test suite: PASS (all tests)
- Frontend lint: PASS

## Changes
- `.agents/skills/verify/SKILL.md` - Added triggers to YAML frontmatter

Closes #fix-verify-skill