### PR TITLE
[unit: auth] PR 13: Rate Limiting

### DIFF
--- a/.agents/memory/short-term/users-auth.json
+++ b/.agents/memory/short-term/users-auth.json
@@ -3,7 +3,7 @@
   "current_phase": "implementation-pr1",
   "status": "in_progress",
   "pending_tasks": ["PR 1: Database Migration", "PR 2: Domain Models", "PR 3: SQLC Queries", "PR 4: Password Service", "PR 5: Token Service", "PR 6: Auth Service", "PR 7: Magic Link Service", "PR 8: Permission Service", "PR 9-11: HTTP Handlers", "PR 12-13: Middleware", "PR 14: Events", "PR 15-16: Config & Server", "PR 17-18: Testing"],
-  "current_pr": 12,
+  "current_pr": 13,
   "completed_documents": [
     "problem_space.md",
     "bsd.md",
@@ -143,10 +143,18 @@
       "phase": "implementation-pr12",
       "notes": [
         "PR 12: Auth Middleware - RequireAuth, RequireRole",
-        "PR #237 open"
+        "PR #237 merged"
       ],
       "timestamp": "2026-04-12T15:34:00Z"
+    },
+    {
+      "phase": "implementation-pr13",
+      "notes": [
+        "PR 13: Rate Limiting - RateLimiter, X-RateLimit headers",
+        "PR #238 open"
+      ],
+      "timestamp": "2026-04-12T15:54:00Z"
     }
   ],
-  "last_updated": "2026-04-12T15:34:00Z"
+  "last_updated": "2026-04-12T15:54:00Z"
 }

--- a/backend/services/api/internal/middleware/rate_limit_middleware.go
+++ b/backend/services/api/internal/middleware/rate_limit_middleware.go
@@ -1,0 +1,207 @@
+// Package middleware provides HTTP middleware for the API service.
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// RateLimiter provides rate limiting functionality using an in-memory map.
+// This is a simple implementation that can be replaced with Valkey later.
+type RateLimiter struct {
+	mu       sync.RWMutex
+	requests map[string]*clientWindow
+	config   RateLimitConfig
+}
+
+// RateLimitConfig holds the configuration for rate limiting.
+type RateLimitConfig struct {
+	MaxRequests    int           // Maximum requests allowed per window
+	WindowDuration time.Duration // Time window for rate limiting
+}
+
+// clientWindow tracks request counts for a specific client within a time window.
+type clientWindow struct {
+	count       int
+	windowStart time.Time
+}
+
+// NewRateLimiter creates a new RateLimiter with the given configuration.
+func NewRateLimiter(config RateLimitConfig) *RateLimiter {
+	return &RateLimiter{
+		requests: make(map[string]*clientWindow),
+		config:   config,
+	}
+}
+
+// LimitByIP checks if the IP address has exceeded the rate limit.
+// Returns true if allowed, false if limit exceeded.
+// The key should be the client's IP address.
+func (rl *RateLimiter) LimitByIP(key string, maxRequests int, window time.Duration) (bool, error) {
+	return rl.checkLimit(key, maxRequests, window)
+}
+
+// LimitByEmail checks if the email has exceeded the rate limit.
+// Returns true if allowed, false if limit exceeded.
+// The key should be the user's email address.
+func (rl *RateLimiter) LimitByEmail(email string, maxRequests int, window time.Duration) (bool, error) {
+	return rl.checkLimit(email, maxRequests, window)
+}
+
+// checkLimit is the internal method that performs the rate limit check.
+func (rl *RateLimiter) checkLimit(key string, maxRequests int, window time.Duration) (bool, error) {
+	now := time.Now()
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	client, exists := rl.requests[key]
+	if !exists {
+		// First request from this client
+		rl.requests[key] = &clientWindow{
+			count:       1,
+			windowStart: now,
+		}
+		return true, nil
+	}
+
+	// Check if the window has expired
+	if now.Sub(client.windowStart) >= window {
+		// Reset the window
+		client.count = 1
+		client.windowStart = now
+		return true, nil
+	}
+
+	// Increment the count and check against limit
+	client.count++
+
+	if client.count > maxRequests {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// GetRemainingRequests returns the number of remaining requests for a key.
+// Returns -1 if the key is not found.
+func (rl *RateLimiter) GetRemainingRequests(key string, maxRequests int, window time.Duration) int {
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+
+	client, exists := rl.requests[key]
+	if !exists {
+		return maxRequests
+	}
+
+	now := time.Now()
+	if now.Sub(client.windowStart) >= window {
+		return maxRequests
+	}
+
+	remaining := maxRequests - client.count
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+// GetResetTime returns the time when the rate limit will reset for a key.
+// Returns zero time if the key is not found.
+func (rl *RateLimiter) GetResetTime(key string, window time.Duration) time.Time {
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+
+	client, exists := rl.requests[key]
+	if !exists {
+		return time.Time{}
+	}
+
+	return client.windowStart.Add(window)
+}
+
+// Middleware returns a rate limiting middleware with the specified configuration.
+// It adds rate limit headers to responses:
+//   - X-RateLimit-Limit: Maximum requests allowed
+//   - X-RateLimit-Remaining: Remaining requests in the current window
+//   - X-RateLimit-Reset: Unix timestamp when the rate limit resets
+//
+// Returns 429 Too Many Requests when the limit is exceeded.
+func (rl *RateLimiter) Middleware(maxRequests int, window time.Duration, keyFunc func(*http.Request) string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key := keyFunc(r)
+			if key == "" {
+				// If no key, allow the request
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			allowed, err := rl.checkLimit(key, maxRequests, window)
+			if err != nil {
+				// On error, allow the request but log
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			remaining := rl.GetRemainingRequests(key, maxRequests, window)
+			resetTime := rl.GetResetTime(key, window)
+
+			// Add rate limit headers
+			w.Header().Set("X-RateLimit-Limit", strconv.Itoa(maxRequests))
+			w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(remaining))
+			if !resetTime.IsZero() {
+				w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetTime.Unix(), 10))
+			}
+
+			if !allowed {
+				http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// RateLimitByIP returns a middleware that rate limits by client IP address.
+func (rl *RateLimiter) RateLimitByIP(maxRequests int, window time.Duration) func(next http.Handler) http.Handler {
+	return rl.Middleware(maxRequests, window, func(r *http.Request) string {
+		// Get client IP, preferring X-Forwarded-For if behind a proxy
+		ip := r.Header.Get("X-Forwarded-For")
+		if ip == "" {
+			ip = r.Header.Get("X-Real-IP")
+		}
+		if ip == "" {
+			ip = r.RemoteAddr
+		}
+		// Take the first IP if there are multiple
+		if idx := len(ip) - 1; idx > 0 {
+			if commaIdx := indexOf(ip, ","); commaIdx > 0 {
+				ip = ip[:commaIdx]
+			}
+		}
+		return ip
+	})
+}
+
+// RateLimitByEmail returns a middleware that rate limits by user email.
+// This middleware expects the email to be in the request context under UserEmailKey.
+// Use this after the auth middleware.
+func (rl *RateLimiter) RateLimitByEmail(maxRequests int, window time.Duration) func(next http.Handler) http.Handler {
+	return rl.Middleware(maxRequests, window, func(r *http.Request) string {
+		return GetUserEmailFromContext(r.Context())
+	})
+}
+
+// indexOf returns the index of the first occurrence of sep in s, or -1 if not found.
+func indexOf(s, sep string) int {
+	for i := 0; i <= len(s)-len(sep); i++ {
+		if s[i:i+len(sep)] == sep {
+			return i
+		}
+	}
+	return -1
+}

--- a/backend/services/api/internal/middleware/rate_limit_middleware_test.go
+++ b/backend/services/api/internal/middleware/rate_limit_middleware_test.go
@@ -1,0 +1,386 @@
+// Package middleware provides HTTP middleware for the API service.
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewRateLimiter(t *testing.T) {
+	config := RateLimitConfig{
+		MaxRequests:    10,
+		WindowDuration: time.Minute,
+	}
+	rl := NewRateLimiter(config)
+
+	if rl == nil {
+		t.Fatal("NewRateLimiter returned nil")
+	}
+	if rl.requests == nil {
+		t.Error("requests map should be initialized")
+	}
+	if rl.config.MaxRequests != 10 {
+		t.Errorf("expected MaxRequests 10, got %d", rl.config.MaxRequests)
+	}
+}
+
+func TestLimitByIP_AllowsRequestsWithinLimit(t *testing.T) {
+	rl := NewRateLimiter(RateLimitConfig{
+		MaxRequests:    5,
+		WindowDuration: time.Minute,
+	})
+
+	// First 5 requests should be allowed
+	for i := 0; i < 5; i++ {
+		allowed, err := rl.LimitByIP("192.168.1.1", 5, time.Minute)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !allowed {
+			t.Errorf("request %d should be allowed", i+1)
+		}
+	}
+}
+
+func TestLimitByIP_BlocksRequestsExceedingLimit(t *testing.T) {
+	rl := NewRateLimiter(RateLimitConfig{
+		MaxRequests:    3,
+		WindowDuration: time.Minute,
+	})
+
+	// First 3 requests should be allowed
+	for i := 0; i < 3; i++ {
+		allowed, _ := rl.LimitByIP("192.168.1.1", 3, time.Minute)
+		if !allowed {
+			t.Errorf("request %d should be allowed", i+1)
+		}
+	}
+
+	// 4th request should be blocked
+	allowed, err := rl.LimitByIP("192.168.1.1", 3, time.Minute)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if allowed {
+		t.Error("4th request should be blocked")
+	}
+}
+
+func TestLimitByIP_DifferentIPsIndependent(t *testing.T) {
+	rl := NewRateLimiter(RateLimitConfig{
+		MaxRequests:    2,
+		WindowDuration: time.Minute,
+	})
+
+	// IP1 reaches limit
+	rl.LimitByIP("192.168.1.1", 2, time.Minute)
+	rl.LimitByIP("192.168.1.1", 2, time.Minute)
+	allowed, _ := rl.LimitByIP("192.168.1.1", 2, time.Minute)
+	if allowed {
+		t.Error("IP1 should be blocked")
+	}
+
+	// IP2 should still be allowed (different IP)
+	allowed, _ = rl.LimitByIP("192.168.1.2", 2, time.Minute)
+	if !allowed {
+		t.Error("IP2 should be allowed")
+	}
+}
+
+func TestLimitByEmail(t *testing.T) {
+	rl := NewRateLimiter(RateLimitConfig{
+		MaxRequests:    2,
+		WindowDuration: time.Minute,
+	})
+
+	// First 2 requests should be allowed
+	for i := 0; i < 2; i++ {
+		allowed, err := rl.LimitByEmail("user@example.com", 2, time.Minute)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !allowed {
+			t.Errorf("request %d should be allowed", i+1)
+		}
+	}
+
+	// 3rd request should be blocked
+	allowed, err := rl.LimitByEmail("user@example.com", 2, time.Minute)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if allowed {
+		t.Error("3rd request should be blocked")
+	}
+}
+
+func TestGetRemainingRequests(t *testing.T) {
+	rl := NewRateLimiter(RateLimitConfig{
+		MaxRequests:    5,
+		WindowDuration: time.Minute,
+	})
+
+	// Before any requests
+	remaining := rl.GetRemainingRequests("192.168.1.1", 5, time.Minute)
+	if remaining != 5 {
+		t.Errorf("expected 5 remaining, got %d", remaining)
+	}
+
+	// After 2 requests
+	rl.LimitByIP("192.168.1.1", 5, time.Minute)
+	rl.LimitByIP("192.168.1.1", 5, time.Minute)
+	remaining = rl.GetRemainingRequests("192.168.1.1", 5, time.Minute)
+	if remaining != 3 {
+		t.Errorf("expected 3 remaining, got %d", remaining)
+	}
+}
+
+func TestGetResetTime(t *testing.T) {
+	rl := NewRateLimiter(RateLimitConfig{
+		MaxRequests:    5,
+		WindowDuration: time.Minute,
+	})
+
+	// Before any requests
+	reset := rl.GetResetTime("192.168.1.1", time.Minute)
+	if !reset.IsZero() {
+		t.Error("reset time should be zero for unknown key")
+	}
+
+	// After a request
+	rl.LimitByIP("192.168.1.1", 5, time.Minute)
+	reset = rl.GetResetTime("192.168.1.1", time.Minute)
+	if reset.IsZero() {
+		t.Error("reset time should not be zero after request")
+	}
+
+	expectedReset := time.Now().Add(time.Minute)
+	if reset.Sub(expectedReset).Abs() > time.Second {
+		t.Errorf("reset time should be approximately now + 1 minute")
+	}
+}
+
+func TestRateLimitByIP_MiddlewareAllowsRequests(t *testing.T) {
+	rl := NewRateLimiter(RateLimitConfig{
+		MaxRequests:    5,
+		WindowDuration: time.Minute,
+	})
+
+	middleware := rl.RateLimitByIP(5, time.Minute)
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if !nextCalled {
+		t.Error("next handler should be called")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+}
+
+func TestRateLimitByIP_MiddlewareBlocksWhenExceeded(t *testing.T) {
+	rl := NewRateLimiter(RateLimitConfig{
+		MaxRequests:    1,
+		WindowDuration: time.Minute,
+	})
+
+	middleware := rl.RateLimitByIP(1, time.Minute)
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware(next)
+
+	// First request should succeed
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if !nextCalled {
+		t.Error("first request should call next handler")
+	}
+
+	// Second request should be blocked
+	nextCalled = false
+	req = httptest.NewRequest(http.MethodGet, "/test", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if nextCalled {
+		t.Error("second request should not call next handler")
+	}
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("expected status 429, got %d", w.Code)
+	}
+}
+
+func TestRateLimitByIP_AddsHeaders(t *testing.T) {
+	rl := NewRateLimiter(RateLimitConfig{
+		MaxRequests:    5,
+		WindowDuration: time.Minute,
+	})
+
+	middleware := rl.RateLimitByIP(5, time.Minute)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	limit := w.Header().Get("X-RateLimit-Limit")
+	remaining := w.Header().Get("X-RateLimit-Remaining")
+	reset := w.Header().Get("X-RateLimit-Reset")
+
+	if limit == "" {
+		t.Error("X-RateLimit-Limit header should be set")
+	}
+	if remaining == "" {
+		t.Error("X-RateLimit-Remaining header should be set")
+	}
+	if reset == "" {
+		t.Error("X-RateLimit-Reset header should be set")
+	}
+}
+
+func TestRateLimitByEmail_Middleware(t *testing.T) {
+	rl := NewRateLimiter(RateLimitConfig{
+		MaxRequests:    2,
+		WindowDuration: time.Minute,
+	})
+
+	middleware := rl.RateLimitByEmail(2, time.Minute)
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware(next)
+
+	// Request with email in context
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	ctx := context.WithValue(req.Context(), UserEmailKey, "user@example.com")
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if !nextCalled {
+		t.Error("next handler should be called")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+}
+
+func TestRateLimitByEmail_BlocksExceeded(t *testing.T) {
+	rl := NewRateLimiter(RateLimitConfig{
+		MaxRequests:    1,
+		WindowDuration: time.Minute,
+	})
+
+	middleware := rl.RateLimitByEmail(1, time.Minute)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware(next)
+
+	// First request
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	ctx := context.WithValue(req.Context(), UserEmailKey, "user@example.com")
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// Second request - should be blocked
+	req = httptest.NewRequest(http.MethodGet, "/test", nil)
+	ctx = context.WithValue(req.Context(), UserEmailKey, "user@example.com")
+	req = req.WithContext(ctx)
+
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("expected status 429, got %d", w.Code)
+	}
+}
+
+func TestRateLimitWindowExpiration(t *testing.T) {
+	rl := NewRateLimiter(RateLimitConfig{
+		MaxRequests:    2,
+		WindowDuration: 100 * time.Millisecond,
+	})
+
+	// Exhaust the limit
+	rl.LimitByIP("192.168.1.1", 2, 100*time.Millisecond)
+	rl.LimitByIP("192.168.1.1", 2, 100*time.Millisecond)
+
+	// Should be blocked
+	allowed, _ := rl.LimitByIP("192.168.1.1", 2, 100*time.Millisecond)
+	if allowed {
+		t.Error("should be blocked before window expiration")
+	}
+
+	// Wait for window to expire
+	time.Sleep(150 * time.Millisecond)
+
+	// Should be allowed after window expiration
+	allowed, _ = rl.LimitByIP("192.168.1.1", 2, 100*time.Millisecond)
+	if !allowed {
+		t.Error("should be allowed after window expiration")
+	}
+}
+
+func TestRateLimit_NoKeyAllowsRequest(t *testing.T) {
+	rl := NewRateLimiter(RateLimitConfig{
+		MaxRequests:    1,
+		WindowDuration: time.Minute,
+	})
+
+	middleware := rl.RateLimitByIP(1, time.Minute)
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	// Clear the RemoteAddr to simulate empty key
+	req.RemoteAddr = ""
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// Should still call next handler (no key = allow)
+	if !nextCalled {
+		t.Error("next handler should be called when no key is available")
+	}
+}

--- a/documentation/changelogs/2026-04-12.md
+++ b/documentation/changelogs/2026-04-12.md
@@ -11,6 +11,7 @@
 - [unit: auth] PR 8: Permission Service - resource-level access control
 - [unit: auth] PR 9-11: HTTP Handlers - auth, session, admin endpoints
 - [unit: auth] PR 12: Auth Middleware - RequireAuth, RequireRole
+- [unit: auth] PR 13: Rate Limiting - RateLimiter, X-RateLimit headers
 
 ## Notes
 - Auth unit implementation in progress (18 micro-PRs)
@@ -23,4 +24,5 @@
 - PR #234 merged (Magic Link Service)
 - PR #235 merged (Permission Service)
 - PR #236 merged (HTTP Handlers)
-- PR #237 open (Auth Middleware)
+- PR #237 merged (Auth Middleware)
+- PR #238 open (Rate Limiting)


### PR DESCRIPTION
## Summary
- RateLimiter with MaxRequests, WindowDuration
- LimitByIP and LimitByEmail methods
- Rate limit headers: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset
- Returns 429 when limit exceeded
- Unit tests

## Files Changed
- backend/services/api/internal/middleware/rate_limit_middleware.go
- backend/services/api/internal/middleware/rate_limit_middleware_test.go

## QA
- Build passes ✅

Waiting for merge.