### PR TITLE
[unit: deployment-dx] Slice 4: Embedded NATS Messaging

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -10,13 +10,18 @@ import (
 
 	"ace/internal/platform"
 	"ace/internal/platform/database"
+	"ace/internal/platform/messaging"
+
+	"github.com/nats-io/nats.go"
 )
 
 // App represents the main ACE application.
 type App struct {
-	Config *Config
-	Paths  *platform.Paths
-	DB     *sql.DB
+	Config      *Config
+	Paths       *platform.Paths
+	DB          *sql.DB
+	NATSConn    *nats.Conn
+	natsCleanup func() error
 }
 
 // New creates a new App instance with the given configuration.
@@ -51,10 +56,27 @@ func New(cfg *Config) (*App, error) {
 		return nil, fmt.Errorf("migrate database: %w", err)
 	}
 
+	// Initialize NATS messaging
+	messagingCfg := &messaging.Config{
+		Mode: cfg.NATSMode,
+		URL:  cfg.NATSURL,
+	}
+	messagingPaths := &messaging.MessagingPaths{
+		NATSPath: paths.NATSPath,
+	}
+
+	nc, natsCleanup, err := messaging.Init(messagingCfg, messagingPaths)
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("init messaging: %w", err)
+	}
+
 	return &App{
-		Config: cfg,
-		Paths:  &paths,
-		DB:     db,
+		Config:      cfg,
+		Paths:       &paths,
+		DB:          db,
+		NATSConn:    nc,
+		natsCleanup: natsCleanup,
 	}, nil
 }
 
@@ -68,6 +90,13 @@ func (a *App) Serve() error {
 
 // Shutdown gracefully shuts down the application.
 func (a *App) Shutdown() error {
+	// Cleanup NATS (drain client then shutdown server)
+	if a.natsCleanup != nil {
+		if err := a.natsCleanup(); err != nil {
+			return fmt.Errorf("cleanup messaging: %w", err)
+		}
+	}
+
 	// Close database connection
 	if a.DB != nil {
 		if err := a.DB.Close(); err != nil {

--- a/backend/internal/platform/messaging/messaging.go
+++ b/backend/internal/platform/messaging/messaging.go
@@ -1,0 +1,41 @@
+// Package messaging provides NATS messaging infrastructure initialization.
+package messaging
+
+import (
+	"fmt"
+
+	"github.com/nats-io/nats.go"
+)
+
+// MessagingPaths holds filesystem paths needed for messaging infrastructure.
+type MessagingPaths struct {
+	// NATSPath is the directory for NATS JetStream storage.
+	NATSPath string
+}
+
+// Config holds messaging configuration.
+type Config struct {
+	// Mode is the messaging mode: "embedded" or "external".
+	Mode string
+	// URL is the NATS server URL (for external mode).
+	URL string
+}
+
+// Init initializes the NATS connection based on configuration.
+// It returns the connection, a cleanup function, and any error encountered.
+func Init(cfg *Config, paths *MessagingPaths) (*nats.Conn, func() error, error) {
+	switch cfg.Mode {
+	case "embedded":
+		return initEmbedded(paths)
+	case "external":
+		return initExternal(cfg.URL)
+	default:
+		return nil, nil, fmt.Errorf("messaging: invalid mode: %q (must be \"embedded\" or \"external\")", cfg.Mode)
+	}
+}
+
+// initExternal is a stub for non-external build.
+// The actual implementation is in server_ext.go with //go:build external tag.
+func initExternal(url string) (*nats.Conn, func() error, error) {
+	return nil, nil, fmt.Errorf("messaging: external mode not available (build with -tags external)")
+}

--- a/backend/internal/platform/messaging/messaging_test.go
+++ b/backend/internal/platform/messaging/messaging_test.go
@@ -1,0 +1,199 @@
+//go:build !external
+
+package messaging
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitEmbedded_StartsAndStops(t *testing.T) {
+	// Create temp directory for NATS storage
+	tmpDir := t.TempDir()
+	natsPath := filepath.Join(tmpDir, "nats")
+
+	paths := &MessagingPaths{
+		NATSPath: natsPath,
+	}
+
+	cfg := &Config{
+		Mode: "embedded",
+	}
+
+	// Initialize embedded NATS
+	nc, cleanup, err := Init(cfg, paths)
+	require.NoError(t, err)
+	require.NotNil(t, nc)
+	require.NotNil(t, cleanup)
+
+	// Verify connection is alive
+	assert.True(t, nc.IsConnected())
+
+	// Cleanup
+	err = cleanup()
+	require.NoError(t, err)
+
+	// Verify NATS data directory was created
+	_, err = os.Stat(natsPath)
+	assert.NoError(t, err)
+}
+
+func TestInitEmbedded_PublishSubscribe(t *testing.T) {
+	tmpDir := t.TempDir()
+	natsPath := filepath.Join(tmpDir, "nats")
+
+	paths := &MessagingPaths{
+		NATSPath: natsPath,
+	}
+
+	cfg := &Config{
+		Mode: "embedded",
+	}
+
+	nc, cleanup, err := Init(cfg, paths)
+	require.NoError(t, err)
+	defer func() {
+		err := cleanup()
+		require.NoError(t, err)
+	}()
+
+	// Subscribe to a test subject
+	received := make(chan []byte, 1)
+	sub, err := nc.Subscribe("test.subject", func(msg *nats.Msg) {
+		received <- msg.Data
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	// Give subscription time to establish
+	time.Sleep(100 * time.Millisecond)
+
+	// Publish a message
+	err = nc.Publish("test.subject", []byte("hello world"))
+	require.NoError(t, err)
+
+	// Wait for message
+	select {
+	case data := <-received:
+		assert.Equal(t, "hello world", string(data))
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+}
+
+func TestInitEmbedded_JetStream(t *testing.T) {
+	tmpDir := t.TempDir()
+	natsPath := filepath.Join(tmpDir, "nats")
+
+	paths := &MessagingPaths{
+		NATSPath: natsPath,
+	}
+
+	cfg := &Config{
+		Mode: "embedded",
+	}
+
+	nc, cleanup, err := Init(cfg, paths)
+	require.NoError(t, err)
+	defer func() {
+		err := cleanup()
+		require.NoError(t, err)
+	}()
+
+	// Get JetStream context
+	js, err := nc.JetStream()
+	require.NoError(t, err)
+
+	// Create a stream
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "TEST_STREAM",
+		Subjects: []string{"test.>"},
+	})
+	require.NoError(t, err)
+
+	// Verify stream exists
+	streamInfo, err := js.StreamInfo("TEST_STREAM")
+	require.NoError(t, err)
+	assert.Equal(t, "TEST_STREAM", streamInfo.Config.Name)
+
+	// Publish and consume a message
+	js.Publish("test.subject", []byte("jetstream message"))
+
+	sub, err := js.Subscribe("test.subject", func(msg *nats.Msg) {
+		assert.Equal(t, "jetstream message", string(msg.Data))
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestMessagingConfig_Defaults(t *testing.T) {
+	cfg := &Config{
+		Mode: "embedded",
+	}
+
+	assert.Equal(t, "embedded", cfg.Mode)
+	assert.Empty(t, cfg.URL)
+}
+
+func TestInitEmbedded_NoTCPPorts(t *testing.T) {
+	// This test verifies that embedded NATS doesn't open TCP ports
+	// by checking that DontListen mode is used
+	tmpDir := t.TempDir()
+	natsPath := filepath.Join(tmpDir, "nats")
+
+	paths := &MessagingPaths{
+		NATSPath: natsPath,
+	}
+
+	cfg := &Config{
+		Mode: "embedded",
+	}
+
+	nc, cleanup, err := Init(cfg, paths)
+	require.NoError(t, err)
+	defer func() {
+		err := cleanup()
+		require.NoError(t, err)
+	}()
+
+	// Verify connection works
+	assert.True(t, nc.IsConnected())
+
+	// The key verification is in the implementation:
+	// server_embed.go uses DontListen: true which prevents TCP listening
+	// and nats.InProcessServer(srv) for in-process connection
+}
+
+func TestInitEmbedded_GracefulShutdown(t *testing.T) {
+	tmpDir := t.TempDir()
+	natsPath := filepath.Join(tmpDir, "nats")
+
+	paths := &MessagingPaths{
+		NATSPath: natsPath,
+	}
+
+	cfg := &Config{
+		Mode: "embedded",
+	}
+
+	nc, cleanup, err := Init(cfg, paths)
+	require.NoError(t, err)
+
+	// Verify connection is alive
+	assert.True(t, nc.IsConnected())
+
+	// Perform graceful shutdown
+	err = cleanup()
+	require.NoError(t, err)
+
+	// Verify connection is closed
+	assert.False(t, nc.IsConnected())
+}

--- a/backend/internal/platform/messaging/server_embed.go
+++ b/backend/internal/platform/messaging/server_embed.go
@@ -1,0 +1,69 @@
+//go:build !external
+
+// Package messaging provides NATS messaging infrastructure initialization.
+package messaging
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+)
+
+// initEmbedded starts an embedded NATS server with JetStream enabled.
+func initEmbedded(paths *MessagingPaths) (*nats.Conn, func() error, error) {
+	// Create the embedded NATS server
+	srv, err := startEmbeddedNATS(paths)
+	if err != nil {
+		return nil, nil, fmt.Errorf("messaging: start embedded NATS: %w", err)
+	}
+
+	// Wait for server to be ready
+	if !srv.ReadyForConnections(5 * time.Second) {
+		srv.Shutdown()
+		return nil, nil, fmt.Errorf("messaging: NATS server not ready")
+	}
+
+	// Connect to the embedded server using in-process connection
+	// This uses srv.InProcessConn() which creates a loopback connection
+	// without opening any TCP ports (DontListen: true)
+	nc, err := nats.Connect(srv.ClientURL(), nats.InProcessServer(srv))
+	if err != nil {
+		srv.Shutdown()
+		return nil, nil, fmt.Errorf("messaging: connect to embedded NATS: %w", err)
+	}
+
+	// Create cleanup function
+	cleanup := func() error {
+		// Drain the client connection first
+		if nc != nil {
+			_ = nc.Drain()
+			nc.Close()
+		}
+		// Shutdown the server
+		srv.Shutdown()
+		return nil
+	}
+
+	return nc, cleanup, nil
+}
+
+// startEmbeddedNATS creates and configures an embedded NATS server.
+func startEmbeddedNATS(paths *MessagingPaths) (*server.Server, error) {
+	opts := &server.Options{
+		DontListen: true, // No TCP ports - in-process only
+		JetStream:  true,
+		StoreDir:   paths.NATSPath,
+	}
+
+	srv, err := server.NewServer(opts)
+	if err != nil {
+		return nil, fmt.Errorf("create NATS server: %w", err)
+	}
+
+	// Start the server in a goroutine
+	go srv.Start()
+
+	return srv, nil
+}

--- a/backend/internal/platform/messaging/server_ext.go
+++ b/backend/internal/platform/messaging/server_ext.go
@@ -1,0 +1,38 @@
+//go:build external
+
+// Package messaging provides NATS messaging infrastructure initialization.
+package messaging
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+// initExternal connects to an external NATS server.
+func initExternal(url string) (*nats.Conn, func() error, error) {
+	if url == "" {
+		return nil, nil, fmt.Errorf("messaging: URL is required for external mode")
+	}
+
+	nc, err := nats.Connect(url,
+		nats.Name("ace-app"),
+		nats.Timeout(10*time.Second),
+		nats.MaxReconnects(3),
+		nats.ReconnectWait(time.Second),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("messaging: connect to NATS: %w", err)
+	}
+
+	cleanup := func() error {
+		if nc != nil {
+			_ = nc.Drain()
+			nc.Close()
+		}
+		return nil
+	}
+
+	return nc, cleanup, nil
+}


### PR DESCRIPTION
## Summary
- Add `internal/platform/messaging/` package with embedded NATS support
- Wire NATS into App lifecycle (init after DB, cleanup before DB close)
- Use `DontListen: true` + `nats.InProcessServer()` for in-process-only NATS (no TCP ports)
- Enable JetStream with StoreDir at `~/.local/share/ace/nats/`
- Add tests for embedded NATS: start/stop, pub/sub, JetStream, graceful shutdown

## Technical Details
- `messaging.Config`: Mode (embedded/external), URL (for external)
- `messaging.Init()`: Returns `*nats.Conn`, cleanup function, error
- `server_embed.go`: Embedded NATS with JetStream (default build)
- `server_ext.go`: External NATS connection (`//go:build external`)
- App now has `NATSConn` field and `natsCleanup` field

## Verification
- `go build ./cmd/ace` compiles
- `./ace` starts with embedded NATS (no TCP ports opened)
- JetStream directory created at `~/.local/share/ace/nats/`
- `./ace` shutdown gracefully drains and stops NATS
- Existing messaging tests pass with in-process connection
- All platform messaging tests pass
- `go test ./... -short` passes