### PR TITLE
feat(deployment-dx): Slice 5 - In-Process Cache (Ristretto)

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgraph-io/ristretto v0.2.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -58,6 +59,7 @@ require (
 	github.com/nats-io/nkeys v0.4.15 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -11,6 +11,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgraph-io/ristretto v0.2.0 h1:XAfl+7cmoUDWW/2Lx8TGZQjjxIQ2Ley9DSf52dru4WE=
+github.com/dgraph-io/ristretto v0.2.0/go.mod h1:8uBHCU/PBV4Ag0CJrP47b9Ofby5dqWNh4FicAdoqFNU=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
@@ -86,6 +88,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/onsi/gomega v1.38.3 h1:eTX+W6dobAYfFeGC2PV6RwXRu/MyT+cQguijutvkpSM=
 github.com/onsi/gomega v1.38.3/go.mod h1:ZCU1pkQcXDO5Sl9/VVEGlDyp+zm0m1cmeG5TOzLgdh4=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pressly/goose/v3 v3.27.0 h1:/D30gVTuQhu0WsNZYbJi4DMOsx1lNq+6SkLe+Wp59BM=

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -8,7 +8,9 @@ import (
 	"os/signal"
 	"syscall"
 
+	"ace/internal/caching"
 	"ace/internal/platform"
+	"ace/internal/platform/cache"
 	"ace/internal/platform/database"
 	"ace/internal/platform/messaging"
 
@@ -22,6 +24,7 @@ type App struct {
 	DB          *sql.DB
 	NATSConn    *nats.Conn
 	natsCleanup func() error
+	Cache       caching.CacheBackend
 }
 
 // New creates a new App instance with the given configuration.
@@ -71,12 +74,27 @@ func New(cfg *Config) (*App, error) {
 		return nil, fmt.Errorf("init messaging: %w", err)
 	}
 
+	// Initialize cache
+	cacheCfg := &cache.Config{
+		Mode:        cfg.CacheMode,
+		URL:         cfg.CacheURL,
+		MaxCost:     int64(cfg.CacheMaxCost),
+		BufferItems: 64,
+	}
+	cacheBackend, err := cache.Init(cacheCfg)
+	if err != nil {
+		nc.Close()
+		db.Close()
+		return nil, fmt.Errorf("init cache: %w", err)
+	}
+
 	return &App{
 		Config:      cfg,
 		Paths:       &paths,
 		DB:          db,
 		NATSConn:    nc,
 		natsCleanup: natsCleanup,
+		Cache:       cacheBackend,
 	}, nil
 }
 
@@ -90,6 +108,13 @@ func (a *App) Serve() error {
 
 // Shutdown gracefully shuts down the application.
 func (a *App) Shutdown() error {
+	// Close cache
+	if a.Cache != nil {
+		if err := a.Cache.Close(); err != nil {
+			return fmt.Errorf("close cache: %w", err)
+		}
+	}
+
 	// Cleanup NATS (drain client then shutdown server)
 	if a.natsCleanup != nil {
 		if err := a.natsCleanup(); err != nil {

--- a/backend/internal/platform/cache/cache.go
+++ b/backend/internal/platform/cache/cache.go
@@ -1,0 +1,39 @@
+// Package cache provides cache backend initialization for the ACE application.
+package cache
+
+import (
+	"fmt"
+
+	"ace/internal/caching"
+)
+
+// Config holds the configuration for the cache backend.
+type Config struct {
+	// Mode is the cache mode: "embedded" or "external".
+	Mode string
+	// URL is the cache server URL (for external mode).
+	URL string
+	// MaxCost is the maximum cost for the in-process cache (bytes).
+	MaxCost int64
+	// BufferItems is the number of items to buffer per write.
+	BufferItems int64
+}
+
+// Init initializes the cache backend based on configuration.
+// It returns the cache backend and any error encountered.
+func Init(cfg *Config) (caching.CacheBackend, error) {
+	switch cfg.Mode {
+	case "embedded":
+		return InitInProcess(cfg)
+	case "external":
+		return InitExternal(cfg)
+	default:
+		return nil, fmt.Errorf("cache: invalid mode: %q (must be \"embedded\" or \"external\")", cfg.Mode)
+	}
+}
+
+// InitExternal is a stub for non-external build.
+// The actual implementation is in valkey.go with //go:build external tag.
+func InitExternal(cfg *Config) (caching.CacheBackend, error) {
+	return nil, fmt.Errorf("cache: external mode not available (build with -tags external)")
+}

--- a/backend/internal/platform/cache/inprocess.go
+++ b/backend/internal/platform/cache/inprocess.go
@@ -1,0 +1,384 @@
+//go:build !external
+
+// Package cache provides Ristretto-based in-process cache backend.
+package cache
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"ace/internal/caching"
+
+	"github.com/dgraph-io/ristretto"
+)
+
+// InProcessBackend implements caching.CacheBackend using Ristretto.
+type InProcessBackend struct {
+	cache    *ristretto.Cache
+	tagIndex *sync.Map // map[string]map[string]struct{} (tagKey -> set of keys)
+	keyIndex *sync.Map // map[string]map[string]struct{} (key -> set of tags)
+	ttlIndex *sync.Map // map[string]time.Time (key -> expiration time)
+	allKeys  *sync.Map // map[string]struct{} (all stored keys for pattern matching)
+	mu       sync.RWMutex
+}
+
+// Compile-time interface check.
+var _ caching.CacheBackend = (*InProcessBackend)(nil)
+
+// InitInProcess creates a new in-process cache backend using Ristretto.
+func InitInProcess(cfg *Config) (*InProcessBackend, error) {
+	maxCost := cfg.MaxCost
+	if maxCost == 0 {
+		maxCost = 52428800 // 50MB default
+	}
+
+	bufferItems := cfg.BufferItems
+	if bufferItems == 0 {
+		bufferItems = 64
+	}
+
+	cache, err := ristretto.NewCache(&ristretto.Config{
+		MaxCost:     maxCost,
+		BufferItems: int64(bufferItems),
+		NumCounters: maxCost / 10,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cache: create Ristretto cache: %w", err)
+	}
+
+	return &InProcessBackend{
+		cache:    cache,
+		tagIndex: &sync.Map{},
+		keyIndex: &sync.Map{},
+		ttlIndex: &sync.Map{},
+		allKeys:  &sync.Map{},
+	}, nil
+}
+
+// Get retrieves a value by key. Returns nil on cache miss.
+func (b *InProcessBackend) Get(ctx context.Context, key string) ([]byte, error) {
+	// Check TTL first
+	if b.isExpired(key) {
+		b.Delete(ctx, key)
+		return nil, nil
+	}
+
+	value, ok := b.cache.Get(key)
+	if !ok || value == nil {
+		return nil, nil
+	}
+
+	bytes, ok := value.([]byte)
+	if !ok {
+		return nil, nil
+	}
+	return bytes, nil
+}
+
+// Set stores a value with a TTL.
+func (b *InProcessBackend) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	if ttl > 0 {
+		expTime := time.Now().Add(ttl)
+		b.ttlIndex.Store(key, expTime)
+	} else {
+		b.ttlIndex.Delete(key)
+	}
+
+	b.cache.Set(key, value, int64(len(value)))
+	b.allKeys.Store(key, struct{}{})
+	return nil
+}
+
+// Delete removes a key.
+func (b *InProcessBackend) Delete(ctx context.Context, key string) error {
+	b.cache.Del(key)
+	b.ttlIndex.Delete(key)
+	b.allKeys.Delete(key)
+
+	// Clean up key -> tags mapping
+	if tags, ok := b.keyIndex.Load(key); ok {
+		tagSet := tags.(map[string]struct{})
+		for tag := range tagSet {
+			if tagMap, ok := b.tagIndex.Load(tag); ok {
+				delete(tagMap.(map[string]struct{}), key)
+			}
+		}
+		b.keyIndex.Delete(key)
+	}
+
+	return nil
+}
+
+// GetMany retrieves multiple keys. Returns only found (hit) entries.
+func (b *InProcessBackend) GetMany(ctx context.Context, keys []string) (map[string][]byte, error) {
+	result := make(map[string][]byte, len(keys))
+	for _, key := range keys {
+		if b.isExpired(key) {
+			b.Delete(ctx, key)
+			continue
+		}
+
+		value, ok := b.cache.Get(key)
+		if !ok {
+			continue
+		}
+
+		if bytes, ok := value.([]byte); ok {
+			result[key] = bytes
+		}
+	}
+	return result, nil
+}
+
+// SetMany stores multiple entries.
+func (b *InProcessBackend) SetMany(ctx context.Context, entries map[string][]byte, ttl time.Duration) error {
+	for key, value := range entries {
+		if err := b.Set(ctx, key, value, ttl); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DeleteMany removes multiple keys.
+func (b *InProcessBackend) DeleteMany(ctx context.Context, keys []string) error {
+	for _, key := range keys {
+		if err := b.Delete(ctx, key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DeletePattern removes all keys matching the pattern.
+// Pattern supports * wildcard matching.
+func (b *InProcessBackend) DeletePattern(ctx context.Context, pattern string) error {
+	if pattern == "" || pattern == "*" {
+		return caching.ErrPatternInvalid
+	}
+
+	// Collect matching keys from our key index
+	var toDelete []string
+	b.allKeys.Range(func(key, _ interface{}) bool {
+		k, ok := key.(string)
+		if !ok {
+			return true
+		}
+		if matchPattern(k, pattern) {
+			toDelete = append(toDelete, k)
+		}
+		return true
+	})
+
+	// Delete matching keys
+	for _, key := range toDelete {
+		b.Delete(ctx, key)
+	}
+
+	return nil
+}
+
+// DeleteByTag removes all entries with the given tag.
+// The tagKey is the full tag key (e.g., _tags:{namespace}:{agentId}:{tag}).
+func (b *InProcessBackend) DeleteByTag(ctx context.Context, tagKey string) error {
+	// Get all keys associated with this tag
+	tagMap, ok := b.tagIndex.Load(tagKey)
+	if !ok {
+		return nil // Tag doesn't exist
+	}
+
+	// Collect keys to delete
+	keys := make([]string, 0, len(tagMap.(map[string]struct{})))
+	for key := range tagMap.(map[string]struct{}) {
+		keys = append(keys, key)
+	}
+
+	// Delete all keys
+	for _, key := range keys {
+		b.Delete(ctx, key)
+	}
+
+	// Delete the tag set itself
+	b.tagIndex.Delete(tagKey)
+
+	return nil
+}
+
+// SAdd adds members to a set with an optional TTL.
+func (b *InProcessBackend) SAdd(ctx context.Context, key string, members []string, ttl time.Duration) error {
+	if len(members) == 0 {
+		return nil
+	}
+
+	// Get or create the tag set
+	set, _ := b.tagIndex.LoadOrStore(key, make(map[string]struct{}))
+	tagSet := set.(map[string]struct{})
+
+	// Add members to the set
+	for _, member := range members {
+		// Track this tag in the key's tag set
+		b.addKeyTag(member, key)
+
+		// Add to tag set
+		tagSet[member] = struct{}{}
+	}
+
+	// Update TTL on the tag set if needed
+	if ttl > 0 {
+		expTime := time.Now().Add(ttl)
+		b.ttlIndex.Store(key, expTime)
+	}
+
+	return nil
+}
+
+// SMembers returns all members of a set.
+func (b *InProcessBackend) SMembers(ctx context.Context, key string) ([]string, error) {
+	// Check if expired
+	if b.isExpired(key) {
+		b.Delete(ctx, key)
+		return []string{}, nil
+	}
+
+	set, ok := b.tagIndex.Load(key)
+	if !ok {
+		return []string{}, nil
+	}
+
+	members := make([]string, 0, len(set.(map[string]struct{})))
+	for member := range set.(map[string]struct{}) {
+		members = append(members, member)
+	}
+
+	return members, nil
+}
+
+// SRem removes members from a set.
+func (b *InProcessBackend) SRem(ctx context.Context, key string, members []string) error {
+	if len(members) == 0 {
+		return nil
+	}
+
+	set, ok := b.tagIndex.Load(key)
+	if !ok {
+		return nil
+	}
+
+	tagSet := set.(map[string]struct{})
+
+	for _, member := range members {
+		delete(tagSet, member)
+		// Remove tag tracking from key
+		b.removeKeyTag(member, key)
+	}
+
+	return nil
+}
+
+// Exists returns true if the key exists.
+func (b *InProcessBackend) Exists(ctx context.Context, key string) (bool, error) {
+	if b.isExpired(key) {
+		b.Delete(ctx, key)
+		return false, nil
+	}
+
+	_, ok := b.cache.Get(key)
+	return ok, nil
+}
+
+// TTL returns the remaining TTL for a key.
+func (b *InProcessBackend) TTL(ctx context.Context, key string) (time.Duration, error) {
+	expTime, ok := b.ttlIndex.Load(key)
+	if !ok {
+		return 0, nil
+	}
+
+	remaining := time.Until(expTime.(time.Time))
+	if remaining <= 0 {
+		b.Delete(ctx, key)
+		return 0, nil
+	}
+
+	return remaining, nil
+}
+
+// Close shuts down the cache.
+func (b *InProcessBackend) Close() error {
+	b.cache.Close()
+	return nil
+}
+
+// addKeyTag records that key has a given tag.
+func (b *InProcessBackend) addKeyTag(key, tag string) {
+	set, _ := b.keyIndex.LoadOrStore(key, make(map[string]struct{}))
+	tagSet := set.(map[string]struct{})
+	tagSet[tag] = struct{}{}
+}
+
+// removeKeyTag removes tag tracking from key.
+func (b *InProcessBackend) removeKeyTag(key, tag string) {
+	if tags, ok := b.keyIndex.Load(key); ok {
+		delete(tags.(map[string]struct{}), tag)
+	}
+}
+
+// isExpired checks if a key has expired.
+func (b *InProcessBackend) isExpired(key string) bool {
+	expTime, ok := b.ttlIndex.Load(key)
+	if !ok {
+		return false
+	}
+	return time.Now().After(expTime.(time.Time))
+}
+
+// matchPattern checks if key matches the given glob pattern.
+// Supports * wildcard which matches any sequence of characters.
+func matchPattern(key, pattern string) bool {
+	if pattern == "" {
+		return key == ""
+	}
+
+	// Convert glob pattern to regex-like matching
+	// * matches any sequence of characters
+	parts := strings.Split(pattern, "*")
+	if len(parts) == 1 {
+		return key == pattern
+	}
+
+	// Simple prefix/suffix matching for single wildcard
+	if len(parts) == 2 {
+		prefix := parts[0]
+		suffix := parts[1]
+		if prefix != "" && !strings.HasPrefix(key, prefix) {
+			return false
+		}
+		if suffix != "" && !strings.HasSuffix(key, suffix) {
+			return false
+		}
+		return true
+	}
+
+	// Multiple wildcards - more complex matching
+	pos := 0
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		if i == 0 {
+			if !strings.HasPrefix(key, part) {
+				return false
+			}
+			pos = len(part)
+		} else {
+			idx := strings.Index(key[pos:], part)
+			if idx == -1 {
+				return false
+			}
+			pos += idx + len(part)
+		}
+	}
+	return true
+}

--- a/backend/internal/platform/cache/inprocess_test.go
+++ b/backend/internal/platform/cache/inprocess_test.go
@@ -1,0 +1,300 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"ace/internal/caching"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// waitForBufferFlush waits for Ristretto's write buffer to be processed.
+// Ristretto is async by design - values go to a buffer and are processed in background.
+func waitForBufferFlush() {
+	time.Sleep(10 * time.Millisecond)
+}
+
+func TestInProcessBackend_SetGet(t *testing.T) {
+	cfg := &Config{MaxCost: 1024 * 1024, BufferItems: 64}
+	backend, err := InitInProcess(cfg)
+	require.NoError(t, err)
+	defer backend.Close()
+
+	ctx := context.Background()
+
+	// Set a value
+	err = backend.Set(ctx, "key1", []byte("value1"), time.Hour)
+	require.NoError(t, err)
+	waitForBufferFlush()
+
+	// Get the value
+	value, err := backend.Get(ctx, "key1")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("value1"), value)
+}
+
+func TestInProcessBackend_Delete(t *testing.T) {
+	cfg := &Config{MaxCost: 1024 * 1024, BufferItems: 64}
+	backend, err := InitInProcess(cfg)
+	require.NoError(t, err)
+	defer backend.Close()
+
+	ctx := context.Background()
+
+	// Set a value
+	err = backend.Set(ctx, "key1", []byte("value1"), time.Hour)
+	require.NoError(t, err)
+	waitForBufferFlush()
+
+	// Delete the value
+	err = backend.Delete(ctx, "key1")
+	require.NoError(t, err)
+
+	// Get should return nil
+	value, err := backend.Get(ctx, "key1")
+	require.NoError(t, err)
+	assert.Nil(t, value)
+}
+
+func TestInProcessBackend_DeleteByTag(t *testing.T) {
+	cfg := &Config{MaxCost: 1024 * 1024, BufferItems: 64}
+	backend, err := InitInProcess(cfg)
+	require.NoError(t, err)
+	defer backend.Close()
+
+	ctx := context.Background()
+
+	// Set values with tags (tag sets are synchronous in our implementation)
+	tagKey := "_tags:test:agent1:myTag"
+	err = backend.SAdd(ctx, tagKey, []string{"key1", "key2"}, time.Hour)
+	require.NoError(t, err)
+
+	// Set the actual values
+	err = backend.Set(ctx, "key1", []byte("value1"), time.Hour)
+	require.NoError(t, err)
+	err = backend.Set(ctx, "key2", []byte("value2"), time.Hour)
+	require.NoError(t, err)
+	waitForBufferFlush()
+
+	// Delete by tag
+	err = backend.DeleteByTag(ctx, tagKey)
+	require.NoError(t, err)
+
+	// Values should be gone
+	value, err := backend.Get(ctx, "key1")
+	require.NoError(t, err)
+	assert.Nil(t, value)
+
+	value, err = backend.Get(ctx, "key2")
+	require.NoError(t, err)
+	assert.Nil(t, value)
+}
+
+func TestInProcessBackend_DeletePattern(t *testing.T) {
+	cfg := &Config{MaxCost: 1024 * 1024, BufferItems: 64}
+	backend, err := InitInProcess(cfg)
+	require.NoError(t, err)
+	defer backend.Close()
+
+	ctx := context.Background()
+
+	// Set values
+	err = backend.Set(ctx, "ns:agent1:user:1", []byte("value1"), time.Hour)
+	require.NoError(t, err)
+	err = backend.Set(ctx, "ns:agent1:user:2", []byte("value2"), time.Hour)
+	require.NoError(t, err)
+	err = backend.Set(ctx, "ns:agent2:user:1", []byte("value3"), time.Hour)
+	require.NoError(t, err)
+	waitForBufferFlush()
+
+	// Delete pattern
+	err = backend.DeletePattern(ctx, "ns:agent1:*")
+	require.NoError(t, err)
+
+	// agent1 keys should be gone
+	value, err := backend.Get(ctx, "ns:agent1:user:1")
+	require.NoError(t, err)
+	assert.Nil(t, value)
+
+	value, err = backend.Get(ctx, "ns:agent1:user:2")
+	require.NoError(t, err)
+	assert.Nil(t, value)
+
+	// agent2 key should still exist
+	value, err = backend.Get(ctx, "ns:agent2:user:1")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("value3"), value)
+}
+
+func TestInProcessBackend_TagIndex(t *testing.T) {
+	cfg := &Config{MaxCost: 1024 * 1024, BufferItems: 64}
+	backend, err := InitInProcess(cfg)
+	require.NoError(t, err)
+	defer backend.Close()
+
+	ctx := context.Background()
+
+	// SADD members to a tag set (synchronous operation)
+	tagKey := "_tags:ns:agent:myTag"
+	err = backend.SAdd(ctx, tagKey, []string{"member1", "member2"}, time.Hour)
+	require.NoError(t, err)
+
+	// SMembers should return all members
+	members, err := backend.SMembers(ctx, tagKey)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"member1", "member2"}, members)
+
+	// SREM should remove members
+	err = backend.SRem(ctx, tagKey, []string{"member1"})
+	require.NoError(t, err)
+
+	members, err = backend.SMembers(ctx, tagKey)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"member2"}, members)
+}
+
+func TestInProcessBackend_MaxCostEviction(t *testing.T) {
+	cfg := &Config{MaxCost: 100, BufferItems: 64} // Very small cache
+	backend, err := InitInProcess(cfg)
+	require.NoError(t, err)
+	defer backend.Close()
+
+	ctx := context.Background()
+
+	// Fill the cache with items larger than max cost
+	for i := 0; i < 10; i++ {
+		key := string(rune('a' + i))
+		value := make([]byte, 50) // Each value is 50 bytes
+		for j := range value {
+			value[j] = byte(i)
+		}
+		err = backend.Set(ctx, key, value, time.Hour)
+		// Ristretto may reject items that exceed max cost, so we don't assert no error
+	}
+	waitForBufferFlush()
+
+	// The cache should still function - at least some items should be stored
+	_, err = backend.Get(ctx, "a")
+	// Either found or not found is fine - cache is working
+	require.NoError(t, err)
+}
+
+func TestInProcessBackend_GetMany(t *testing.T) {
+	cfg := &Config{MaxCost: 1024 * 1024, BufferItems: 64}
+	backend, err := InitInProcess(cfg)
+	require.NoError(t, err)
+	defer backend.Close()
+
+	ctx := context.Background()
+
+	// Set some values
+	err = backend.Set(ctx, "key1", []byte("value1"), time.Hour)
+	require.NoError(t, err)
+	err = backend.Set(ctx, "key2", []byte("value2"), time.Hour)
+	require.NoError(t, err)
+	waitForBufferFlush()
+
+	// GetMany
+	result, err := backend.GetMany(ctx, []string{"key1", "key2", "key3"})
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, []byte("value1"), result["key1"])
+	assert.Equal(t, []byte("value2"), result["key2"])
+}
+
+func TestInProcessBackend_SetMany(t *testing.T) {
+	cfg := &Config{MaxCost: 1024 * 1024, BufferItems: 64}
+	backend, err := InitInProcess(cfg)
+	require.NoError(t, err)
+	defer backend.Close()
+
+	ctx := context.Background()
+
+	// SetMany
+	entries := map[string][]byte{
+		"key1": []byte("value1"),
+		"key2": []byte("value2"),
+	}
+	err = backend.SetMany(ctx, entries, time.Hour)
+	require.NoError(t, err)
+	waitForBufferFlush()
+
+	// Verify
+	value, err := backend.Get(ctx, "key1")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("value1"), value)
+}
+
+func TestInProcessBackend_Exists(t *testing.T) {
+	cfg := &Config{MaxCost: 1024 * 1024, BufferItems: 64}
+	backend, err := InitInProcess(cfg)
+	require.NoError(t, err)
+	defer backend.Close()
+
+	ctx := context.Background()
+
+	// Set a value
+	err = backend.Set(ctx, "key1", []byte("value1"), time.Hour)
+	require.NoError(t, err)
+	waitForBufferFlush()
+
+	// Exists should return true
+	exists, err := backend.Exists(ctx, "key1")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	// Non-existent key
+	exists, err = backend.Exists(ctx, "nonexistent")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestInProcessBackend_TTL(t *testing.T) {
+	cfg := &Config{MaxCost: 1024 * 1024, BufferItems: 64}
+	backend, err := InitInProcess(cfg)
+	require.NoError(t, err)
+	defer backend.Close()
+
+	ctx := context.Background()
+
+	// Set a value with TTL
+	err = backend.Set(ctx, "key1", []byte("value1"), 2*time.Hour)
+	require.NoError(t, err)
+	waitForBufferFlush()
+
+	// TTL should be positive and close to 2 hours
+	ttl, err := backend.TTL(ctx, "key1")
+	require.NoError(t, err)
+	assert.Greater(t, ttl, time.Hour)
+	assert.LessOrEqual(t, ttl, 2*time.Hour)
+
+	// Key without TTL
+	err = backend.Set(ctx, "key2", []byte("value2"), 0)
+	require.NoError(t, err)
+	ttl, err = backend.TTL(ctx, "key2")
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), ttl)
+}
+
+func TestInProcessBackend_Close(t *testing.T) {
+	cfg := &Config{MaxCost: 1024 * 1024, BufferItems: 64}
+	backend, err := InitInProcess(cfg)
+	require.NoError(t, err)
+
+	// Close should not error
+	err = backend.Close()
+	require.NoError(t, err)
+}
+
+func TestInProcessBackend_ImplementsCacheBackend(t *testing.T) {
+	cfg := &Config{MaxCost: 1024 * 1024, BufferItems: 64}
+	backend, err := InitInProcess(cfg)
+	require.NoError(t, err)
+	defer backend.Close()
+
+	// Compile-time interface check
+	var _ caching.CacheBackend = backend
+}

--- a/backend/internal/platform/cache/valkey.go
+++ b/backend/internal/platform/cache/valkey.go
@@ -1,0 +1,16 @@
+//go:build external
+
+// Package cache provides external Valkey-based cache backend.
+package cache
+
+import (
+	"fmt"
+
+	"ace/internal/caching"
+)
+
+// InitExternal creates a new external Valkey cache backend.
+func InitExternal(cfg *Config) (caching.CacheBackend, error) {
+	// Valkey backend is imported and used directly from caching package
+	return nil, fmt.Errorf("cache: external Valkey mode not yet implemented")
+}


### PR DESCRIPTION
## Summary
- Add Ristretto dependency for in-process caching
- Create `internal/platform/cache/` package with:
  - `Config` struct for cache mode, max cost, buffer items
  - `Init()` factory for embedded/external modes
  - `InProcessBackend` implementing `caching.CacheBackend` interface
- Implement all CacheBackend methods:
  - `Get/Set/Delete` for basic operations
  - `GetMany/SetMany/DeleteMany` for bulk operations
  - `DeleteByTag` for tag-based invalidation
  - `DeletePattern` for glob-based invalidation
  - `SAdd/SMembers/SRem` for set operations
  - `Exists/TTL` for metadata
- Add tag index map for tag-based invalidation
- Add allKeys index for pattern matching
- Wire cache into App: `New()` initializes cache, `Shutdown()` closes

## Definition of Done
- [x] InProcessBackend implements all CacheBackend methods
- [x] Tag invalidation works
- [x] Memory budget enforced (Ristretto eviction)
- [x] App starts with Ristretto cache
- [x] All cache tests pass

## Verification
- `go build ./cmd/ace` compiles
- `./ace` starts with Ristretto cache
- `make test` passes