### PR TITLE
[unit: deployment-dx] Slice 6: Custom Telemetry (SQLite Exporters)

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/adrg/xdg v0.5.3
+	github.com/dgraph-io/ristretto v0.2.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-playground/validator/v10 v10.30.2
 	github.com/google/uuid v1.6.0
@@ -27,6 +28,7 @@ require (
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.50.0
 	golang.org/x/sync v0.20.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.48.2
 )
@@ -37,7 +39,6 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dgraph-io/ristretto v0.2.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -13,6 +13,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/ristretto v0.2.0 h1:XAfl+7cmoUDWW/2Lx8TGZQjjxIQ2Ley9DSf52dru4WE=
 github.com/dgraph-io/ristretto v0.2.0/go.mod h1:8uBHCU/PBV4Ag0CJrP47b9Ofby5dqWNh4FicAdoqFNU=
+github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 h1:fAjc9m62+UWV/WAFKLNi6ZS0675eEUC9y3AlwSbQu1Y=
+github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
@@ -182,6 +184,8 @@ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -2,17 +2,20 @@
 package app
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"ace/internal/caching"
 	"ace/internal/platform"
 	"ace/internal/platform/cache"
 	"ace/internal/platform/database"
 	"ace/internal/platform/messaging"
+	"ace/internal/platform/telemetry"
 
 	"github.com/nats-io/nats.go"
 )
@@ -25,11 +28,14 @@ type App struct {
 	NATSConn    *nats.Conn
 	natsCleanup func() error
 	Cache       caching.CacheBackend
+	Telemetry   *telemetry.Telemetry
 }
 
 // New creates a new App instance with the given configuration.
 // It resolves paths, creates necessary directories, and opens the database.
 func New(cfg *Config) (*App, error) {
+	ctx := context.Background()
+
 	// Resolve filesystem paths
 	paths, err := platform.ResolvePaths(cfg.DataDir)
 	if err != nil {
@@ -88,6 +94,23 @@ func New(cfg *Config) (*App, error) {
 		return nil, fmt.Errorf("init cache: %w", err)
 	}
 
+	// Initialize telemetry
+	telemetryCfg := &telemetry.Config{
+		Mode:          cfg.TelemetryMode,
+		OTLPEndpoint:  cfg.OTLPEndpoint,
+		ServiceName:   "ace",
+		Environment:   "development",
+		LogDir:        paths.LogDir,
+		PruneInterval: 6 * time.Hour,
+	}
+	appTelemetry, err := telemetry.Init(ctx, telemetryCfg, db)
+	if err != nil {
+		cacheBackend.Close()
+		nc.Close()
+		db.Close()
+		return nil, fmt.Errorf("init telemetry: %w", err)
+	}
+
 	return &App{
 		Config:      cfg,
 		Paths:       &paths,
@@ -95,6 +118,7 @@ func New(cfg *Config) (*App, error) {
 		NATSConn:    nc,
 		natsCleanup: natsCleanup,
 		Cache:       cacheBackend,
+		Telemetry:   appTelemetry,
 	}, nil
 }
 
@@ -108,27 +132,48 @@ func (a *App) Serve() error {
 
 // Shutdown gracefully shuts down the application.
 func (a *App) Shutdown() error {
+	var errs []error
+
+	// Stop pruning goroutine
+	if a.Telemetry != nil && a.Telemetry.PruneStop != nil {
+		a.Telemetry.PruneStop()
+	}
+
+	// Flush and shutdown telemetry
+	if a.Telemetry != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := a.Telemetry.Shutdown(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("shutdown telemetry: %w", err))
+		}
+	}
+
 	// Close cache
 	if a.Cache != nil {
 		if err := a.Cache.Close(); err != nil {
-			return fmt.Errorf("close cache: %w", err)
+			errs = append(errs, fmt.Errorf("close cache: %w", err))
 		}
 	}
 
 	// Cleanup NATS (drain client then shutdown server)
 	if a.natsCleanup != nil {
 		if err := a.natsCleanup(); err != nil {
-			return fmt.Errorf("cleanup messaging: %w", err)
+			errs = append(errs, fmt.Errorf("cleanup messaging: %w", err))
 		}
 	}
 
 	// Close database connection
 	if a.DB != nil {
 		if err := a.DB.Close(); err != nil {
-			return fmt.Errorf("close database: %w", err)
+			errs = append(errs, fmt.Errorf("close database: %w", err))
 		}
 	}
+
 	fmt.Println("shutting down")
+
+	if len(errs) > 0 {
+		return fmt.Errorf("shutdown errors: %v", errs)
+	}
 	return nil
 }
 

--- a/backend/internal/platform/telemetry/inspector.go
+++ b/backend/internal/platform/telemetry/inspector.go
@@ -1,0 +1,431 @@
+package telemetry
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Inspector handles telemetry inspection HTTP endpoints.
+type Inspector struct {
+	db     *sql.DB
+	logger *zap.Logger
+}
+
+// NewInspector creates a new telemetry inspector.
+func NewInspector(db *sql.DB, logger *zap.Logger) *Inspector {
+	return &Inspector{
+		db:     db,
+		logger: logger,
+	}
+}
+
+// RegisterRoutes registers the inspector HTTP routes.
+func (i *Inspector) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/telemetry/spans", i.handleSpans)
+	mux.HandleFunc("/telemetry/metrics", i.handleMetrics)
+	mux.HandleFunc("/telemetry/usage", i.handleUsage)
+	mux.HandleFunc("/telemetry/health", i.handleHealth)
+}
+
+// Span represents a trace span from the database.
+type Span struct {
+	TraceID      string                 `json:"trace_id"`
+	SpanID       string                 `json:"span_id"`
+	ParentSpanID string                 `json:"parent_span_id,omitempty"`
+	Operation    string                 `json:"operation"`
+	Service      string                 `json:"service"`
+	StartTime    string                 `json:"start_time"`
+	EndTime      string                 `json:"end_time"`
+	DurationMs   int64                  `json:"duration_ms"`
+	Status       string                 `json:"status"`
+	Attributes   map[string]interface{} `json:"attributes,omitempty"`
+}
+
+// handleSpans handles GET /telemetry/spans
+func (i *Inspector) handleSpans(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ctx := r.Context()
+
+	// Parse query parameters
+	limit := 50
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 && parsed <= 1000 {
+			limit = parsed
+		}
+	}
+
+	offset := 0
+	if o := r.URL.Query().Get("offset"); o != "" {
+		if parsed, err := strconv.Atoi(o); err == nil && parsed >= 0 {
+			offset = parsed
+		}
+	}
+
+	service := r.URL.Query().Get("service")
+	operation := r.URL.Query().Get("operation")
+
+	// Build query
+	query := `
+		SELECT trace_id, span_id, parent_span_id, operation_name, service_name,
+		       start_time, end_time, duration_ms, status, attributes
+		FROM ott_spans
+		WHERE 1=1
+	`
+	args := []interface{}{}
+	argIdx := 1
+
+	if service != "" {
+		query += fmt.Sprintf(" AND service_name = $%d", argIdx)
+		args = append(args, service)
+		argIdx++
+	}
+	if operation != "" {
+		query += fmt.Sprintf(" AND operation_name = $%d", argIdx)
+		args = append(args, operation)
+		argIdx++
+	}
+
+	query += fmt.Sprintf(" ORDER BY start_time DESC LIMIT $%d OFFSET $%d", argIdx, argIdx+1)
+	args = append(args, limit, offset)
+
+	rows, err := i.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		i.logger.Error("failed to query spans", zap.Error(err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	spans := make([]Span, 0)
+	for rows.Next() {
+		var s Span
+		var attrsJSON sql.NullString
+		var parentSpanID sql.NullString
+
+		err := rows.Scan(
+			&s.TraceID, &s.SpanID, &parentSpanID, &s.Operation, &s.Service,
+			&s.StartTime, &s.EndTime, &s.DurationMs, &s.Status, &attrsJSON,
+		)
+		if err != nil {
+			i.logger.Error("failed to scan span", zap.Error(err))
+			continue
+		}
+
+		if parentSpanID.Valid {
+			s.ParentSpanID = parentSpanID.String
+		}
+		if attrsJSON.Valid && attrsJSON.String != "" {
+			if err := json.Unmarshal([]byte(attrsJSON.String), &s.Attributes); err != nil {
+				s.Attributes = make(map[string]interface{})
+			}
+		}
+
+		spans = append(spans, s)
+	}
+
+	// Get total count
+	var total int
+	countQuery := "SELECT COUNT(*) FROM ott_spans WHERE 1=1"
+	if service != "" {
+		countQuery += " AND service_name = ?"
+	}
+	if operation != "" {
+		countQuery += " AND operation_name = ?"
+	}
+
+	countArgs := []interface{}{}
+	if service != "" {
+		countArgs = append(countArgs, service)
+	}
+	if operation != "" {
+		countArgs = append(countArgs, operation)
+	}
+
+	i.db.QueryRowContext(ctx, countQuery, countArgs...).Scan(&total)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"spans":  spans,
+		"total":  total,
+		"limit":  limit,
+		"offset": offset,
+	})
+}
+
+// Metric represents a metric from the database.
+type Metric struct {
+	Name      string            `json:"name"`
+	Type      string            `json:"type"`
+	Labels    map[string]string `json:"labels"`
+	Value     float64           `json:"value"`
+	Timestamp string            `json:"timestamp"`
+}
+
+// handleMetrics handles GET /telemetry/metrics
+func (i *Inspector) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ctx := r.Context()
+
+	// Parse query parameters
+	limit := 50
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 && parsed <= 200 {
+			limit = parsed
+		}
+	}
+
+	name := r.URL.Query().Get("name")
+
+	// Build query
+	query := `
+		SELECT name, type, labels, value, timestamp
+		FROM ott_metrics
+		WHERE 1=1
+	`
+	args := []interface{}{}
+	if name != "" {
+		query += " AND name = ?"
+		args = append(args, name)
+	}
+
+	query += " ORDER BY timestamp DESC LIMIT ? OFFSET 0"
+	args = append(args, limit)
+
+	rows, err := i.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		i.logger.Error("failed to query metrics", zap.Error(err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	metrics := make([]Metric, 0)
+	for rows.Next() {
+		var m Metric
+		var labelsJSON string
+
+		err := rows.Scan(&m.Name, &m.Type, &labelsJSON, &m.Value, &m.Timestamp)
+		if err != nil {
+			i.logger.Error("failed to scan metric", zap.Error(err))
+			continue
+		}
+
+		if labelsJSON != "" {
+			if err := json.Unmarshal([]byte(labelsJSON), &m.Labels); err != nil {
+				m.Labels = make(map[string]string)
+			}
+		} else {
+			m.Labels = make(map[string]string)
+		}
+
+		metrics = append(metrics, m)
+	}
+
+	// Get total count
+	var total int
+	i.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM ott_metrics").Scan(&total)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"metrics": metrics,
+		"total":   total,
+		"limit":   limit,
+	})
+}
+
+// UsageEvent represents a usage event from the database.
+type UsageEvent struct {
+	ID           int64   `json:"id"`
+	AgentID      string  `json:"agent_id"`
+	SessionID    string  `json:"session_id"`
+	EventType    string  `json:"event_type"`
+	Model        string  `json:"model,omitempty"`
+	InputTokens  int64   `json:"input_tokens,omitempty"`
+	OutputTokens int64   `json:"output_tokens,omitempty"`
+	CostUSD      float64 `json:"cost_usd,omitempty"`
+	DurationMs   int64   `json:"duration_ms,omitempty"`
+	Timestamp    string  `json:"timestamp"`
+}
+
+// handleUsage handles GET /telemetry/usage
+func (i *Inspector) handleUsage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ctx := r.Context()
+
+	// Parse query parameters
+	limit := 100
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 && parsed <= 500 {
+			limit = parsed
+		}
+	}
+
+	offset := 0
+	if o := r.URL.Query().Get("offset"); o != "" {
+		if parsed, err := strconv.Atoi(o); err == nil && parsed >= 0 {
+			offset = parsed
+		}
+	}
+
+	agentID := r.URL.Query().Get("agent_id")
+	eventType := r.URL.Query().Get("event_type")
+
+	// Build query
+	query := `
+		SELECT id, agent_id, session_id, event_type, model,
+		       input_tokens, output_tokens, cost_usd, duration_ms, created_at
+		FROM usage_events
+		WHERE 1=1
+	`
+	args := []interface{}{}
+
+	if agentID != "" {
+		query += " AND agent_id = ?"
+		args = append(args, agentID)
+	}
+	if eventType != "" {
+		query += " AND event_type = ?"
+		args = append(args, eventType)
+	}
+
+	query += " ORDER BY created_at DESC LIMIT ? OFFSET ?"
+	args = append(args, limit, offset)
+
+	rows, err := i.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		i.logger.Error("failed to query usage events", zap.Error(err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	events := make([]UsageEvent, 0)
+	for rows.Next() {
+		var e UsageEvent
+		var model sql.NullString
+		var inputTokens, outputTokens sql.NullInt64
+		var costUSD sql.NullFloat64
+		var durationMs sql.NullInt64
+
+		err := rows.Scan(
+			&e.ID, &e.AgentID, &e.SessionID, &e.EventType, &model,
+			&inputTokens, &outputTokens, &costUSD, &durationMs, &e.Timestamp,
+		)
+		if err != nil {
+			i.logger.Error("failed to scan usage event", zap.Error(err))
+			continue
+		}
+
+		if model.Valid {
+			e.Model = model.String
+		}
+		if inputTokens.Valid {
+			e.InputTokens = inputTokens.Int64
+		}
+		if outputTokens.Valid {
+			e.OutputTokens = outputTokens.Int64
+		}
+		if costUSD.Valid {
+			e.CostUSD = costUSD.Float64
+		}
+		if durationMs.Valid {
+			e.DurationMs = durationMs.Int64
+		}
+
+		events = append(events, e)
+	}
+
+	// Get total count
+	var total int
+	countQuery := "SELECT COUNT(*) FROM usage_events WHERE 1=1"
+	countArgs := []interface{}{}
+	if agentID != "" {
+		countQuery += " AND agent_id = ?"
+		countArgs = append(countArgs, agentID)
+	}
+	if eventType != "" {
+		countQuery += " AND event_type = ?"
+		countArgs = append(countArgs, eventType)
+	}
+	i.db.QueryRowContext(ctx, countQuery, countArgs...).Scan(&total)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"events": events,
+		"total":  total,
+		"limit":  limit,
+		"offset": offset,
+	})
+}
+
+// handleHealth handles GET /telemetry/health
+func (i *Inspector) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	response := map[string]interface{}{
+		"status": "healthy",
+		"checks": map[string]interface{}{
+			"database": map[string]interface{}{
+				"status": "ok",
+			},
+		},
+	}
+
+	// Check database connectivity
+	if err := i.db.PingContext(ctx); err != nil {
+		response["status"] = "degraded"
+		response["checks"].(map[string]interface{})["database"] = map[string]interface{}{
+			"status": "error",
+			"error":  err.Error(),
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+
+	// Get spans count from last hour
+	var spansLastHour int64
+	i.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM ott_spans 
+		WHERE created_at > datetime('now', '-1 hour')
+	`).Scan(&spansLastHour)
+
+	// Get metrics count from last hour
+	var metricsLastHour int64
+	i.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM ott_metrics 
+		WHERE created_at > datetime('now', '-1 hour')
+	`).Scan(&metricsLastHour)
+
+	response["checks"].(map[string]interface{})["telemetry"] = map[string]interface{}{
+		"status":            "ok",
+		"spans_last_hour":   spansLastHour,
+		"metrics_last_hour": metricsLastHour,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}

--- a/backend/internal/platform/telemetry/logger.go
+++ b/backend/internal/platform/telemetry/logger.go
@@ -1,0 +1,128 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// NewLogger creates a structured JSON logger with dual output (stdout + file).
+// The file output uses lumberjack for log rotation.
+func NewLogger(serviceName, environment, logDir string) (*zap.Logger, error) {
+	// Determine log level based on environment
+	level := zapcore.InfoLevel
+	if environment == "development" || environment == "dev" {
+		level = zapcore.DebugLevel
+	}
+
+	// Create encoder config for JSON output
+	encoderConfig := zapcore.EncoderConfig{
+		TimeKey:        "timestamp",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		CallerKey:      "",
+		MessageKey:     "message",
+		StacktraceKey:  "",
+		LineEnding:     zapcore.DefaultLineEnding,
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.SecondsDurationEncoder,
+		EncodeName:     zapcore.FullNameEncoder,
+	}
+
+	// Build JSON encoder
+	encoder := zapcore.NewJSONEncoder(encoderConfig)
+
+	// Create file output with lumberjack rotation
+	var fileSyncer zapcore.WriteSyncer
+	if logDir != "" {
+		// Ensure log directory exists
+		if err := os.MkdirAll(logDir, 0700); err != nil {
+			// Fall back to stdout only if we can't create log dir
+			fileSyncer = zapcore.AddSync(os.Stdout)
+		} else {
+			lumberjackLogger := &lumberjack.Logger{
+				Filename:   filepath.Join(logDir, "ace.log"),
+				MaxSize:    100, // MB
+				MaxBackups: 3,
+				MaxAge:     28, // days
+				Compress:   true,
+			}
+			fileSyncer = zapcore.AddSync(lumberjackLogger)
+		}
+	} else {
+		fileSyncer = zapcore.AddSync(os.Stdout)
+	}
+
+	// Createtee to write to both stdout and file
+	var stdoutSyncer zapcore.WriteSyncer
+	if logDir != "" {
+		stdoutSyncer = zapcore.NewMultiWriteSyncer(
+			zapcore.AddSync(os.Stdout),
+			fileSyncer,
+		)
+	} else {
+		stdoutSyncer = zapcore.AddSync(os.Stdout)
+	}
+
+	// Build logger with level and dual output
+	logger := zap.New(
+		zapcore.NewTee(
+			zapcore.NewCore(encoder, stdoutSyncer, level),
+		),
+	)
+
+	// Add service name as global field (mandatory)
+	logger = logger.With(
+		zap.String("service_name", serviceName),
+	)
+
+	return logger, nil
+}
+
+// NewLoggerWithStdout creates a logger that only writes to stdout.
+func NewLoggerWithStdout(serviceName, environment string) (*zap.Logger, error) {
+	// Determine log level based on environment
+	level := zapcore.InfoLevel
+	if environment == "development" || environment == "dev" {
+		level = zapcore.DebugLevel
+	}
+
+	// Create encoder config for JSON output
+	encoderConfig := zapcore.EncoderConfig{
+		TimeKey:        "timestamp",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		CallerKey:      "",
+		MessageKey:     "message",
+		StacktraceKey:  "",
+		LineEnding:     zapcore.DefaultLineEnding,
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.SecondsDurationEncoder,
+		EncodeName:     zapcore.FullNameEncoder,
+	}
+
+	// Build JSON encoder
+	encoder := zapcore.NewJSONEncoder(encoderConfig)
+
+	// Create stdout syncer
+	stdoutSyncer := zapcore.AddSync(os.Stdout)
+
+	// Build logger with level
+	logger := zap.New(
+		zapcore.NewTee(
+			zapcore.NewCore(encoder, stdoutSyncer, level),
+		),
+	)
+
+	// Add service name as global field (mandatory)
+	logger = logger.With(
+		zap.String("service_name", serviceName),
+	)
+
+	return logger, nil
+}

--- a/backend/internal/platform/telemetry/server_ext.go
+++ b/backend/internal/platform/telemetry/server_ext.go
@@ -1,0 +1,63 @@
+//go:build external
+
+package telemetry
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	"go.uber.org/zap"
+)
+
+// InitExternal initializes OTel SDK with external OTLP collectors.
+func InitExternal(ctx context.Context, cfg *Config, logger *zap.Logger) (func(context.Context) error, func(context.Context) error, error) {
+	// Create OTLP trace exporter
+	traceExporter, err := otlptracegrpc.New(ctx,
+		otlptracegrpc.WithEndpoint(cfg.OTLPEndpoint),
+		otlptracegrpc.WithInsecure(),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create OTLP trace exporter: %w", err)
+	}
+
+	// Create resource
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(cfg.ServiceName),
+			semconv.DeploymentEnvironment(cfg.Environment),
+		),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create resource: %w", err)
+	}
+
+	// Create trace provider with OTLP exporter
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(traceExporter),
+		sdktrace.WithResource(res),
+	)
+
+	// Create meter provider (external mode uses default Prometheus)
+	mp := sdkmetric.NewMeterProvider()
+
+	// Set global providers
+	otel.SetTracerProvider(tp)
+	otel.SetMeterProvider(mp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	logger.Info("external telemetry configured",
+		zap.String("otlp_endpoint", cfg.OTLPEndpoint),
+	)
+
+	return tp.Shutdown, mp.Shutdown, nil
+}

--- a/backend/internal/platform/telemetry/sqlite_exporter.go
+++ b/backend/internal/platform/telemetry/sqlite_exporter.go
@@ -1,0 +1,162 @@
+package telemetry
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+// SQLiteSpanExporter implements trace.SpanExporter for SQLite storage.
+type SQLiteSpanExporter struct {
+	db *sql.DB
+}
+
+// NewSQLiteSpanExporter creates a new SQLite span exporter.
+func NewSQLiteSpanExporter(db *sql.DB) (*SQLiteSpanExporter, error) {
+	return &SQLiteSpanExporter{db: db}, nil
+}
+
+// ExportSpans exports spans to the SQLite database.
+func (e *SQLiteSpanExporter) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpan) error {
+	if len(spans) == 0 {
+		return nil
+	}
+
+	tx, err := e.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO ott_spans (
+			trace_id, span_id, parent_span_id, operation_name, service_name,
+			start_time, end_time, duration_ms, status, attributes
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`)
+	if err != nil {
+		return fmt.Errorf("prepare statement: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, span := range spans {
+		// Marshal span attributes to JSON
+		attrs := make(map[string]interface{})
+
+		// Get service name from resource
+		serviceName := ""
+		for _, attr := range span.Resource().Attributes() {
+			if attr.Key == "service.name" {
+				serviceName = fmt.Sprintf("%v", attr.Value)
+				break
+			}
+		}
+
+		for _, attr := range span.Resource().Attributes() {
+			attrs[string(attr.Key)] = formatSpanAttrValue(attr.Value)
+		}
+		for _, attr := range span.Attributes() {
+			attrs[string(attr.Key)] = formatSpanAttrValue(attr.Value)
+		}
+
+		attrsJSON, err := json.Marshal(attrs)
+		if err != nil {
+			attrsJSON = []byte("{}")
+		}
+
+		// Determine status
+		status := "ok"
+		if span.Status().Code == codes.Error {
+			status = "error"
+		}
+
+		// Get parent span ID
+		parentSpanID := ""
+		if span.Parent().IsValid() {
+			parentSpanID = span.Parent().SpanID().String()
+		}
+
+		// Get operation name
+		operationName := span.Name()
+
+		_, err = stmt.ExecContext(ctx,
+			span.SpanContext().TraceID().String(),
+			span.SpanContext().SpanID().String(),
+			parentSpanID,
+			operationName,
+			serviceName,
+			span.StartTime().Format(time.RFC3339Nano),
+			span.EndTime().Format(time.RFC3339Nano),
+			span.EndTime().Sub(span.StartTime()).Milliseconds(),
+			status,
+			string(attrsJSON),
+		)
+		if err != nil {
+			return fmt.Errorf("insert span: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// formatSpanAttrValue converts an attribute value to a string representation.
+func formatSpanAttrValue(v attribute.Value) string {
+	switch v.Type() {
+	case attribute.STRING:
+		return v.AsString()
+	case attribute.BOOL:
+		if v.AsBool() {
+			return "true"
+		}
+		return "false"
+	case attribute.INT64:
+		return fmt.Sprintf("%d", v.AsInt64())
+	case attribute.FLOAT64:
+		return fmt.Sprintf("%f", v.AsFloat64())
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// Shutdown shuts down the exporter.
+func (e *SQLiteSpanExporter) Shutdown(ctx context.Context) error {
+	// No-op for SQLite exporter - connection is managed externally
+	return nil
+}
+
+// ConsoleSpanExporter is a simple span exporter for debugging.
+type ConsoleSpanExporter struct{}
+
+// NewConsoleSpanExporter creates a new console span exporter.
+func NewConsoleSpanExporter() *ConsoleSpanExporter {
+	return &ConsoleSpanExporter{}
+}
+
+// ExportSpans prints spans to stdout.
+func (e *ConsoleSpanExporter) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpan) error {
+	for _, span := range spans {
+		fmt.Printf("Span: %s/%s (%s) %s %dms\n",
+			span.SpanContext().TraceID().String(),
+			span.SpanContext().SpanID().String(),
+			span.Name(),
+			span.Status().Code,
+			span.EndTime().Sub(span.StartTime()).Milliseconds(),
+		)
+	}
+	return nil
+}
+
+// Shutdown shuts down the exporter.
+func (e *ConsoleSpanExporter) Shutdown(ctx context.Context) error {
+	return nil
+}

--- a/backend/internal/platform/telemetry/sqlite_exporter_metric.go
+++ b/backend/internal/platform/telemetry/sqlite_exporter_metric.go
@@ -1,0 +1,143 @@
+package telemetry
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// SQLiteMetricExporter implements metric.Exporter for SQLite storage.
+type SQLiteMetricExporter struct {
+	db *sql.DB
+}
+
+// NewSQLiteMetricExporter creates a new SQLite metric exporter.
+func NewSQLiteMetricExporter(db *sql.DB) (*SQLiteMetricExporter, error) {
+	return &SQLiteMetricExporter{db: db}, nil
+}
+
+// Temporality returns the temporality for an instrument kind.
+func (e *SQLiteMetricExporter) Temporality(k metric.InstrumentKind) metricdata.Temporality {
+	return metricdata.CumulativeTemporality
+}
+
+// Aggregation returns the aggregation to use for an instrument kind.
+func (e *SQLiteMetricExporter) Aggregation(k metric.InstrumentKind) metric.Aggregation {
+	return metric.DefaultAggregationSelector(k)
+}
+
+// Export exports metrics to the SQLite database.
+func (e *SQLiteMetricExporter) Export(ctx context.Context, rm *metricdata.ResourceMetrics) error {
+	if rm == nil {
+		return nil
+	}
+
+	tx, err := e.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO ott_metrics (name, type, labels, value, timestamp)
+		VALUES (?, ?, ?, ?, ?)
+	`)
+	if err != nil {
+		return fmt.Errorf("prepare statement: %w", err)
+	}
+	defer stmt.Close()
+
+	ts := time.Now().Format(time.RFC3339)
+
+	for _, scopeMetrics := range rm.ScopeMetrics {
+		for _, m := range scopeMetrics.Metrics {
+			// Convert metric data to appropriate representation
+			var name string
+			var metricType string
+			var value float64
+			var labels map[string]string
+
+			name = m.Name
+
+			switch data := m.Data.(type) {
+			case metricdata.Sum[float64]:
+				metricType = "counter"
+				if len(data.DataPoints) > 0 {
+					value = data.DataPoints[len(data.DataPoints)-1].Value
+				}
+				labels = collectMetricLabels(data.DataPoints[len(data.DataPoints)-1].Attributes)
+			case metricdata.Sum[int64]:
+				metricType = "counter"
+				if len(data.DataPoints) > 0 {
+					value = float64(data.DataPoints[len(data.DataPoints)-1].Value)
+				}
+				labels = collectMetricLabels(data.DataPoints[len(data.DataPoints)-1].Attributes)
+			case metricdata.Gauge[float64]:
+				metricType = "gauge"
+				if len(data.DataPoints) > 0 {
+					value = data.DataPoints[len(data.DataPoints)-1].Value
+				}
+				labels = collectMetricLabels(data.DataPoints[len(data.DataPoints)-1].Attributes)
+			case metricdata.Gauge[int64]:
+				metricType = "gauge"
+				if len(data.DataPoints) > 0 {
+					value = float64(data.DataPoints[len(data.DataPoints)-1].Value)
+				}
+				labels = collectMetricLabels(data.DataPoints[len(data.DataPoints)-1].Attributes)
+			case metricdata.Histogram[float64]:
+				metricType = "histogram"
+				if len(data.DataPoints) > 0 {
+					value = data.DataPoints[len(data.DataPoints)-1].Sum
+				}
+				labels = collectMetricLabels(data.DataPoints[len(data.DataPoints)-1].Attributes)
+			default:
+				metricType = "unknown"
+				value = 0
+				labels = make(map[string]string)
+			}
+
+			labelsJSON, err := json.Marshal(labels)
+			if err != nil {
+				labelsJSON = []byte("{}")
+			}
+
+			_, err = stmt.ExecContext(ctx, name, metricType, string(labelsJSON), value, ts)
+			if err != nil {
+				return fmt.Errorf("insert metric: %w", err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// collectMetricLabels extracts labels from an attribute.Set.
+func collectMetricLabels(set attribute.Set) map[string]string {
+	labels := make(map[string]string)
+	iter := set.Iter()
+	for iter.Next() {
+		attr := iter.Attribute()
+		labels[string(attr.Key)] = fmt.Sprintf("%v", attr.Value)
+	}
+	return labels
+}
+
+// Shutdown shuts down the exporter.
+func (e *SQLiteMetricExporter) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+// ForceFlush flushes any pending data.
+func (e *SQLiteMetricExporter) ForceFlush(ctx context.Context) error {
+	return nil
+}

--- a/backend/internal/platform/telemetry/telemetry.go
+++ b/backend/internal/platform/telemetry/telemetry.go
@@ -1,0 +1,299 @@
+// Package telemetry provides custom OpenTelemetry initialization with SQLite exporters.
+package telemetry
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+)
+
+// Config holds telemetry configuration for the platform layer.
+type Config struct {
+	Mode          string // "embedded" or "external"
+	OTLPEndpoint  string // Used when mode is "external"
+	ServiceName   string
+	Environment   string
+	LogDir        string
+	PruneInterval time.Duration
+}
+
+// Telemetry holds all observability components for the platform.
+type Telemetry struct {
+	Logger    *zap.Logger
+	Tracer    trace.Tracer
+	Meter     metric.Meter
+	DB        *sql.DB
+	Shutdown  func(context.Context) error
+	PruneStop func()
+}
+
+// Init initializes the telemetry subsystem with SQLite exporters for embedded mode.
+func Init(ctx context.Context, cfg *Config, db *sql.DB) (*Telemetry, error) {
+	// Create dual-output logger
+	logger, err := NewLogger(cfg.ServiceName, cfg.Environment, cfg.LogDir)
+	if err != nil {
+		return nil, fmt.Errorf("init logger: %w", err)
+	}
+
+	var shutdownTrace func(context.Context) error
+	var shutdownMetric func(context.Context) error
+
+	// Initialize based on mode
+	if cfg.Mode == "embedded" {
+		shutdownTrace, shutdownMetric, err = initEmbedded(ctx, cfg, db, logger)
+	} else {
+		shutdownTrace, shutdownMetric, err = initExternal(ctx, cfg, logger)
+	}
+	if err != nil {
+		logger.Error("failed to initialize telemetry", zap.Error(err))
+		return nil, fmt.Errorf("init telemetry: %w", err)
+	}
+
+	// Combined shutdown function
+	shutdown := func(ctx context.Context) error {
+		var errs []error
+		if shutdownTrace != nil {
+			if err := shutdownTrace(ctx); err != nil {
+				errs = append(errs, fmt.Errorf("shutdown tracer: %w", err))
+			}
+		}
+		if shutdownMetric != nil {
+			if err := shutdownMetric(ctx); err != nil {
+				errs = append(errs, fmt.Errorf("shutdown meter: %w", err))
+			}
+		}
+		if err := logger.Sync(); err != nil {
+			errs = append(errs, fmt.Errorf("sync logger: %w", err))
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("telemetry shutdown errors: %v", errs)
+		}
+		return nil
+	}
+
+	tel := &Telemetry{
+		Logger:   logger,
+		Tracer:   otel.GetTracerProvider().Tracer(cfg.ServiceName),
+		Meter:    otel.GetMeterProvider().Meter(cfg.ServiceName),
+		DB:       db,
+		Shutdown: shutdown,
+	}
+
+	// Start pruning goroutine
+	stopPrune := startPruning(ctx, db, cfg.PruneInterval, logger)
+	tel.PruneStop = stopPrune
+
+	logger.Info("telemetry initialized",
+		zap.String("mode", cfg.Mode),
+		zap.String("service_name", cfg.ServiceName),
+	)
+
+	return tel, nil
+}
+
+// initEmbedded initializes OTel SDK with SQLite exporters.
+func initEmbedded(ctx context.Context, cfg *Config, db *sql.DB, logger *zap.Logger) (func(context.Context) error, func(context.Context) error, error) {
+	// Create SQLite span exporter
+	spanExporter, err := NewSQLiteSpanExporter(db)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create span exporter: %w", err)
+	}
+
+	// Create SQLite metric exporter
+	metricExporter, err := NewSQLiteMetricExporter(db)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create metric exporter: %w", err)
+	}
+
+	// Create periodic reader for metrics (exports every 10 seconds)
+	metricReader := sdkmetric.NewPeriodicReader(metricExporter,
+		sdkmetric.WithInterval(10*time.Second),
+	)
+
+	// Create resource
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(cfg.ServiceName),
+			semconv.DeploymentEnvironment(cfg.Environment),
+		),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create resource: %w", err)
+	}
+
+	// Create trace provider with SQLite exporter
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(spanExporter),
+		sdktrace.WithResource(res),
+	)
+
+	// Create meter provider with periodic reader
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(metricReader),
+		sdkmetric.WithResource(res),
+	)
+
+	// Set global providers
+	otel.SetTracerProvider(tp)
+	otel.SetMeterProvider(mp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	return tp.Shutdown, mp.Shutdown, nil
+}
+
+// initExternal initializes OTel SDK with OTLP exporters.
+func initExternal(ctx context.Context, cfg *Config, logger *zap.Logger) (func(context.Context) error, func(context.Context) error, error) {
+	// Create OTLP trace exporter
+	traceExporter, err := otlptracegrpc.New(ctx,
+		otlptracegrpc.WithEndpoint(cfg.OTLPEndpoint),
+		otlptracegrpc.WithInsecure(),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create OTLP trace exporter: %w", err)
+	}
+
+	// Create resource
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(cfg.ServiceName),
+			semconv.DeploymentEnvironment(cfg.Environment),
+		),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create resource: %w", err)
+	}
+
+	// Create trace provider with OTLP exporter
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(traceExporter),
+		sdktrace.WithResource(res),
+	)
+
+	// Create meter provider (external mode uses default Prometheus)
+	mp := sdkmetric.NewMeterProvider()
+
+	// Set global providers
+	otel.SetTracerProvider(tp)
+	otel.SetMeterProvider(mp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	logger.Info("external telemetry configured",
+		zap.String("otlp_endpoint", cfg.OTLPEndpoint),
+	)
+
+	return tp.Shutdown, mp.Shutdown, nil
+}
+
+// startPruning starts a goroutine that periodically prunes old telemetry data.
+func startPruning(ctx context.Context, db *sql.DB, interval time.Duration, logger *zap.Logger) func() {
+	stopCh := make(chan struct{})
+
+	go func() {
+		// Run immediately on startup
+		pruneAll(ctx, db, logger)
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				pruneAll(ctx, db, logger)
+			case <-stopCh:
+				logger.Info("pruning goroutine stopped")
+				return
+			case <-ctx.Done():
+				logger.Info("pruning goroutine context cancelled")
+				return
+			}
+		}
+	}()
+
+	return func() {
+		close(stopCh)
+	}
+}
+
+// pruneAll prunes all telemetry tables.
+func pruneAll(ctx context.Context, db *sql.DB, logger *zap.Logger) {
+	// Prune spans older than 7 days
+	if err := pruneSpans(ctx, db); err != nil {
+		logger.Warn("failed to prune spans", zap.Error(err))
+	}
+
+	// Prune metrics older than 24 hours
+	if err := pruneMetrics(ctx, db); err != nil {
+		logger.Warn("failed to prune metrics", zap.Error(err))
+	}
+
+	// Prune usage events older than 90 days
+	if err := pruneUsageEvents(ctx, db); err != nil {
+		logger.Warn("failed to prune usage events", zap.Error(err))
+	}
+}
+
+// pruneSpans deletes spans older than 7 days.
+func pruneSpans(ctx context.Context, db *sql.DB) error {
+	result, err := db.ExecContext(ctx, `
+		DELETE FROM ott_spans 
+		WHERE created_at < datetime('now', '-7 days')
+	`)
+	if err != nil {
+		return err
+	}
+	rows, _ := result.RowsAffected()
+	if rows > 0 {
+		return nil
+	}
+	return nil
+}
+
+// pruneMetrics deletes metrics older than 24 hours.
+func pruneMetrics(ctx context.Context, db *sql.DB) error {
+	result, err := db.ExecContext(ctx, `
+		DELETE FROM ott_metrics 
+		WHERE created_at < datetime('now', '-1 day')
+	`)
+	if err != nil {
+		return err
+	}
+	rows, _ := result.RowsAffected()
+	if rows > 0 {
+		return nil
+	}
+	return nil
+}
+
+// pruneUsageEvents deletes usage events older than 90 days.
+func pruneUsageEvents(ctx context.Context, db *sql.DB) error {
+	result, err := db.ExecContext(ctx, `
+		DELETE FROM usage_events 
+		WHERE created_at < datetime('now', '-90 days')
+	`)
+	if err != nil {
+		return err
+	}
+	rows, _ := result.RowsAffected()
+	if rows > 0 {
+		return nil
+	}
+	return nil
+}

--- a/backend/internal/platform/telemetry/telemetry_test.go
+++ b/backend/internal/platform/telemetry/telemetry_test.go
@@ -1,0 +1,506 @@
+package telemetry
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"ace/internal/platform/database"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestNewSQLiteSpanExporter(t *testing.T) {
+	// Create temporary directory for test database
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Open test database
+	db, err := sql.Open("sqlite", filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Create tables
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS ott_spans (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			trace_id TEXT NOT NULL,
+			span_id TEXT NOT NULL,
+			parent_span_id TEXT,
+			operation_name TEXT NOT NULL,
+			service_name TEXT NOT NULL,
+			start_time TEXT NOT NULL,
+			end_time TEXT NOT NULL,
+			duration_ms INTEGER NOT NULL,
+			status TEXT NOT NULL DEFAULT 'ok',
+			attributes TEXT,
+			created_at TEXT NOT NULL DEFAULT (datetime('now'))
+		)
+	`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	// Test creating exporter
+	exporter, err := NewSQLiteSpanExporter(db)
+	if err != nil {
+		t.Fatalf("failed to create exporter: %v", err)
+	}
+
+	if exporter == nil {
+		t.Fatal("expected non-nil exporter")
+	}
+
+	// Test shutdown
+	err = exporter.Shutdown(context.Background())
+	if err != nil {
+		t.Fatalf("shutdown failed: %v", err)
+	}
+}
+
+func TestNewSQLiteMetricExporter(t *testing.T) {
+	// Create temporary directory for test database
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Open test database
+	db, err := sql.Open("sqlite", filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Create tables
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS ott_metrics (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			type TEXT NOT NULL DEFAULT 'counter',
+			labels TEXT,
+			value REAL NOT NULL,
+			timestamp TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT (datetime('now'))
+		)
+	`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	// Test creating exporter
+	exporter, err := NewSQLiteMetricExporter(db)
+	if err != nil {
+		t.Fatalf("failed to create exporter: %v", err)
+	}
+
+	if exporter == nil {
+		t.Fatal("expected non-nil exporter")
+	}
+
+	// Test temporality
+	temporality := exporter.Temporality(metric.InstrumentKindCounter)
+	if temporality != metricdata.CumulativeTemporality {
+		t.Errorf("expected cumulative temporality, got %v", temporality)
+	}
+
+	// Test aggregation
+	agg := exporter.Aggregation(metric.InstrumentKindCounter)
+	if agg == nil {
+		t.Error("expected non-nil aggregation")
+	}
+
+	// Test shutdown
+	err = exporter.Shutdown(context.Background())
+	if err != nil {
+		t.Fatalf("shutdown failed: %v", err)
+	}
+}
+
+func TestPruneSpans(t *testing.T) {
+	// Create temporary directory for test database
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Open test database
+	db, err := sql.Open("sqlite", filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Create tables
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS ott_spans (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			trace_id TEXT NOT NULL,
+			span_id TEXT NOT NULL,
+			parent_span_id TEXT,
+			operation_name TEXT NOT NULL,
+			service_name TEXT NOT NULL,
+			start_time TEXT NOT NULL,
+			end_time TEXT NOT NULL,
+			duration_ms INTEGER NOT NULL,
+			status TEXT NOT NULL DEFAULT 'ok',
+			attributes TEXT,
+			created_at TEXT NOT NULL
+		)
+	`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	// Insert test spans - one recent, one old
+	now := time.Now().Format(time.RFC3339)
+	oldTime := time.Now().Add(-8 * 24 * time.Hour).Format(time.RFC3339) // 8 days ago
+
+	_, err = db.Exec(`INSERT INTO ott_spans (trace_id, span_id, operation_name, service_name, start_time, end_time, duration_ms, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"trace1", "span1", "op1", "svc1", now, now, 100, "ok", now)
+	if err != nil {
+		t.Fatalf("failed to insert recent span: %v", err)
+	}
+
+	_, err = db.Exec(`INSERT INTO ott_spans (trace_id, span_id, operation_name, service_name, start_time, end_time, duration_ms, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"trace2", "span2", "op2", "svc2", oldTime, oldTime, 100, "ok", oldTime)
+	if err != nil {
+		t.Fatalf("failed to insert old span: %v", err)
+	}
+
+	// Verify we have 2 spans
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM ott_spans").Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to count spans: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 spans, got %d", count)
+	}
+
+	// Prune old spans
+	err = pruneSpans(context.Background(), db)
+	if err != nil {
+		t.Fatalf("pruneSpans failed: %v", err)
+	}
+
+	// Verify we have 1 span (the recent one)
+	err = db.QueryRow("SELECT COUNT(*) FROM ott_spans").Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to count spans after prune: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 span after prune, got %d", count)
+	}
+}
+
+func TestPruneMetrics(t *testing.T) {
+	// Create temporary directory for test database
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Open test database
+	db, err := sql.Open("sqlite", filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Create tables
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS ott_metrics (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			type TEXT NOT NULL DEFAULT 'counter',
+			labels TEXT,
+			value REAL NOT NULL,
+			timestamp TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		)
+	`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	// Insert test metrics - one recent, one old (using SQLite datetime format for proper comparison)
+	now := time.Now().Format("2006-01-02 15:04:05")
+	oldTime := time.Now().Add(-48 * time.Hour).Format("2006-01-02 15:04:05") // 48 hours ago (clearly older than 24h threshold)
+
+	_, err = db.Exec(`INSERT INTO ott_metrics (name, type, value, timestamp, created_at) VALUES (?, ?, ?, ?, ?)`,
+		"metric1", "counter", 1.0, now, now)
+	if err != nil {
+		t.Fatalf("failed to insert recent metric: %v", err)
+	}
+
+	_, err = db.Exec(`INSERT INTO ott_metrics (name, type, value, timestamp, created_at) VALUES (?, ?, ?, ?, ?)`,
+		"metric2", "counter", 1.0, oldTime, oldTime)
+	if err != nil {
+		t.Fatalf("failed to insert old metric: %v", err)
+	}
+
+	// Verify we have 2 metrics
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM ott_metrics").Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to count metrics: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 metrics, got %d", count)
+	}
+
+	// Prune old metrics
+	err = pruneMetrics(context.Background(), db)
+	if err != nil {
+		t.Fatalf("pruneMetrics failed: %v", err)
+	}
+
+	// Verify we have 1 metric (the recent one)
+	err = db.QueryRow("SELECT COUNT(*) FROM ott_metrics").Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to count metrics after prune: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 metric after prune, got %d", count)
+	}
+}
+
+func TestPruneUsageEvents(t *testing.T) {
+	// Create temporary directory for test database
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Open test database
+	db, err := sql.Open("sqlite", filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Create tables
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS usage_events (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			agent_id TEXT NOT NULL,
+			session_id TEXT NOT NULL,
+			event_type TEXT NOT NULL,
+			model TEXT,
+			input_tokens INTEGER,
+			output_tokens INTEGER,
+			cost_usd REAL,
+			duration_ms INTEGER,
+			metadata TEXT,
+			created_at TEXT NOT NULL
+		)
+	`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	// Insert test events - one recent, one old
+	now := time.Now().Format(time.RFC3339)
+	oldTime := time.Now().Add(-91 * 24 * time.Hour).Format(time.RFC3339) // 91 days ago
+
+	_, err = db.Exec(`INSERT INTO usage_events (agent_id, session_id, event_type, created_at) VALUES (?, ?, ?, ?)`,
+		"agent1", "session1", "llm_call", now)
+	if err != nil {
+		t.Fatalf("failed to insert recent event: %v", err)
+	}
+
+	_, err = db.Exec(`INSERT INTO usage_events (agent_id, session_id, event_type, created_at) VALUES (?, ?, ?, ?)`,
+		"agent2", "session2", "llm_call", oldTime)
+	if err != nil {
+		t.Fatalf("failed to insert old event: %v", err)
+	}
+
+	// Verify we have 2 events
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM usage_events").Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to count events: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 events, got %d", count)
+	}
+
+	// Prune old events
+	err = pruneUsageEvents(context.Background(), db)
+	if err != nil {
+		t.Fatalf("pruneUsageEvents failed: %v", err)
+	}
+
+	// Verify we have 1 event (the recent one)
+	err = db.QueryRow("SELECT COUNT(*) FROM usage_events").Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to count events after prune: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 event after prune, got %d", count)
+	}
+}
+
+func TestNewLogger(t *testing.T) {
+	// Create temporary directory for log file
+	tmpDir, err := os.MkdirTemp("", "telemetry-log-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logDir := filepath.Join(tmpDir, "logs")
+
+	// Create logger with file output
+	logger, err := NewLogger("test-service", "development", logDir)
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+
+	if logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+
+	// Log a test message
+	logger.Info("test message")
+
+	// Sync the logger (ignore sync errors in test environment)
+	_ = logger.Sync()
+
+	// Check that log file was created
+	logFile := filepath.Join(logDir, "ace.log")
+	if _, err := os.Stat(logFile); os.IsNotExist(err) {
+		t.Error("expected log file to be created")
+	}
+}
+
+func TestNewLoggerWithStdout(t *testing.T) {
+	// Create logger with stdout only
+	logger, err := NewLoggerWithStdout("test-service", "development")
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+
+	if logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+
+	// Log a test message
+	logger.Info("test message")
+
+	// Sync the logger (ignore sync errors in test environment)
+	_ = logger.Sync()
+}
+
+func TestInspector(t *testing.T) {
+	// Create temporary directory for test database
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Open test database
+	db, err := sql.Open("sqlite", filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Create tables
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS ott_spans (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			trace_id TEXT NOT NULL,
+			span_id TEXT NOT NULL,
+			parent_span_id TEXT,
+			operation_name TEXT NOT NULL,
+			service_name TEXT NOT NULL,
+			start_time TEXT NOT NULL,
+			end_time TEXT NOT NULL,
+			duration_ms INTEGER NOT NULL,
+			status TEXT NOT NULL DEFAULT 'ok',
+			attributes TEXT,
+			created_at TEXT NOT NULL
+		);
+
+		CREATE TABLE IF NOT EXISTS ott_metrics (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			type TEXT NOT NULL DEFAULT 'counter',
+			labels TEXT,
+			value REAL NOT NULL,
+			timestamp TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		);
+
+		CREATE TABLE IF NOT EXISTS usage_events (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			agent_id TEXT NOT NULL,
+			session_id TEXT NOT NULL,
+			event_type TEXT NOT NULL,
+			model TEXT,
+			input_tokens INTEGER,
+			output_tokens INTEGER,
+			cost_usd REAL,
+			duration_ms INTEGER,
+			metadata TEXT,
+			created_at TEXT NOT NULL
+		);
+	`)
+	if err != nil {
+		t.Fatalf("failed to create tables: %v", err)
+	}
+
+	// Create inspector
+	inspector := NewInspector(db, nil)
+	if inspector == nil {
+		t.Fatal("expected non-nil inspector")
+	}
+
+	// Test health endpoint
+	// Note: we can't easily test HTTP handlers without a full server setup
+	// but we can verify the inspector is properly initialized
+	if inspector.db != db {
+		t.Error("inspector database not set correctly")
+	}
+}
+
+// Helper function used in tests - must be in the same package
+func openTestDB(t *testing.T) (*sql.DB, func()) {
+	tmpDir, err := os.MkdirTemp("", "ace-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+
+	db, err := database.Open(&database.Config{
+		Mode:    "embedded",
+		DataDir: tmpDir,
+	})
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		t.Fatalf("failed to open database: %v", err)
+	}
+
+	cleanup := func() {
+		db.Close()
+		os.RemoveAll(tmpDir)
+	}
+
+	return db, cleanup
+}

--- a/backend/internal/telemetry/usage.go
+++ b/backend/internal/telemetry/usage.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"time"
 
@@ -43,23 +44,35 @@ const (
 	ResourceTypeMessaging = "messaging"
 )
 
-// UsagePublisher publishes usage events to NATS
+// UsagePublisher publishes usage events to NATS or directly to DB
 type UsagePublisher struct {
 	nc *nats.Conn
+	db *sql.DB
 }
 
-// NewUsagePublisher creates a new usage event publisher
+// NewUsagePublisher creates a new usage event publisher (NATS mode)
 func NewUsagePublisher(nc *nats.Conn) *UsagePublisher {
 	return &UsagePublisher{nc: nc}
 }
 
-// Publish emits a usage event to NATS
+// NewDBUsagePublisher creates a usage event publisher that writes directly to DB
+func NewDBUsagePublisher(db *sql.DB) *UsagePublisher {
+	return &UsagePublisher{db: db}
+}
+
+// Publish emits a usage event to NATS or DB depending on configuration
 func (p *UsagePublisher) Publish(ctx context.Context, event UsageEvent) error {
+	event.Timestamp = time.Now().UTC()
+
+	// If DB is configured, write directly to DB (embedded mode)
+	if p.db != nil {
+		return p.publishToDB(ctx, event)
+	}
+
+	// Otherwise publish to NATS (external mode)
 	if p.nc == nil {
 		return ErrNATSNotConnected
 	}
-
-	event.Timestamp = time.Now().UTC()
 
 	data, err := json.Marshal(event)
 	if err != nil {
@@ -71,10 +84,36 @@ func (p *UsagePublisher) Publish(ctx context.Context, event UsageEvent) error {
 		Data:    data,
 	}
 
-	// Inject trace context if available
 	InjectTraceContext(ctx, msg)
 
 	return p.nc.PublishMsg(msg)
+}
+
+// publishToDB writes the usage event directly to the database
+func (p *UsagePublisher) publishToDB(ctx context.Context, event UsageEvent) error {
+	metadataJSON, err := json.Marshal(event.Metadata)
+	if err != nil {
+		metadataJSON = []byte("{}")
+	}
+
+	_, err = p.db.ExecContext(ctx, `
+		INSERT INTO usage_events (
+			agent_id, session_id, event_type, model,
+			input_tokens, output_tokens, cost_usd, duration_ms, metadata
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		event.AgentID,
+		event.SessionID,
+		event.OperationType,
+		"", // model - not set in this event type
+		event.TokenCount,
+		0, // output tokens not tracked here
+		event.CostUSD,
+		event.DurationMs,
+		string(metadataJSON),
+	)
+
+	return err
 }
 
 // LLMCall publishes an LLM call usage event


### PR DESCRIPTION
## Summary
- Implement custom OpenTelemetry SDK initialization with SQLite exporters for embedded mode
- SQLiteSpanExporter writes spans to `ott_spans` table
- SQLiteMetricExporter writes metrics to `ott_metrics` table via PeriodicReader
- Dual-output logger (stdout JSON + file with lumberjack rotation)
- Telemetry Inspector HTTP handlers for `/telemetry/*` endpoints (spans, metrics, usage, health)
- Add pruning goroutine (7d spans, 24h metrics, 90d usage events)
- Update `internal/telemetry/usage.go` with direct DB writes in embedded mode
- Wire telemetry into App lifecycle

## Files Changed
- `backend/internal/platform/telemetry/` (new package)
  - `telemetry.go`: Config, Telemetry struct, Init() function
  - `sqlite_exporter.go`: SQLiteSpanExporter for trace spans
  - `sqlite_exporter_metric.go`: SQLiteMetricExporter for metrics
  - `logger.go`: Dual-output logger with lumberjack rotation
  - `inspector.go`: HTTP handlers for telemetry inspection endpoints
  - `server_ext.go`: External mode stub for OTLP exporters
  - `telemetry_test.go`: Unit tests
- `backend/internal/app/app.go`: Wire telemetry init/shutdown
- `backend/internal/telemetry/usage.go`: Add DB-based publisher for embedded mode

## Verification
- `go build ./cmd/ace/` compiles
- `go test ./internal/platform/telemetry/...` passes
- `go test ./internal/...` passes