### PR TITLE
[unit: deployment-dx] Update design docs to reflect completed deployment-dx unit

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -31,18 +31,19 @@ This is the most important section. Misunderstanding it will cause you to build 
 ### System Topology
 
 ```
-                                        ┌──────────┴──────────┐
-                                        │                     │
-                                 ┌───────▼──────┐   ┌──────────▼──────┐   ┌───────────────┐
-                                 │    ace_db    │   │   ace_broker    │   │   ace_valkey  │
-                                 │ Postgres 18  │   │ NATS 2.12 + JS  │   │  Valkey 8     │
-                                 │   :5432      │   │    :4222        │   │   :6379       │
-                                 └──────────────┘   └─────────────────┘   └───────────────┘
+                    ┌─────────────────────────────────────────────────────────────┐
+                    │                         ace                                   │
+                    │  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────┐  │
+                    │  │   SQLite    │  │ embedded    │  │      Ristretto       │  │
+                    │  │  (database) │  │   NATS      │  │      (cache)         │  │
+                    │  │   :5432     │  │  (broker)   │  │                     │  │
+                    │  └─────────────┘  └─────────────┘  └─────────────────────┘  │
+                    └─────────────────────────────────────────────────────────────┘
 ```
 
-The API is the only service today. All future services communicate exclusively via NATS — never through a shared database connection or direct HTTP calls to each other. This constraint exists because services must be independently deployable and independently scalable. In a Kubernetes swarm, cognitive engine pods scale horizontally while the API remains a single entry point, and that independence requires a clean boundary.
+ACE is delivered as a **single binary** with all infrastructure embedded: SQLite for persistence, an embedded NATS server for messaging, and Ristretto for in-process caching. This eliminates external service dependencies and enables frictionless local development and single-node production deployments. All cognitive engine components run within the same process, communicating via the internal bus rather than over the network.
 
-The observability pipeline runs alongside all services: OTel Collector ingests traces via OTLP gRPC, metrics via Prometheus scrape, and logs via filelog from Docker stdout, routing them to Tempo, Prometheus, and Loki. Observability here is not just ops tooling — it directly powers user-facing product features. The Layer Inspector, cost dashboards, and reliability indicators all query the same pipeline. This is why the observability contracts (UsageEvent shape, span attribute names, log field names) are as stable as the API contracts.
+The observability stack is SQLite-backed: traces, metrics, and logs are written to a local SQLite database rather than routed through an external pipeline. This simplifies operations while maintaining full observability for the Layer Inspector, cost dashboards, and reliability indicators. The observability contracts (UsageEvent shape, span attribute names, log field names) remain as stable as the API contracts.
 
 ### Agent Swarm Architecture
 
@@ -262,15 +263,13 @@ router.Use(telemetry.LoggerMiddleware(cfg.ServiceName)) // logs HTTP requests
 ### `shared/caching`
 
 ```go
-// Create backend and cache on service startup
-backend, err := caching.NewValkeyBackend(caching.ValkeyConfig{
-    Addr: "ace_valkey:6379",
+// Create cache on service startup using Ristretto (in-process)
+cache := caching.NewCache(caching.RistrettoConfig{
+    MaxCost:     1 << 30, // 1GB max cost
+    Metrics:     true,
+    AgentID:     agentID,
+    DefaultTTL:  5 * time.Minute,
 })
-cache := caching.NewCache(backend,
-    caching.WithNamespace("my-namespace"),
-    caching.WithAgentID(agentID),
-    caching.WithDefaultTTL(5*time.Minute),
-)
 
 // Core operations
 cache.Set(ctx, "user:123", value, caching.WithTags("user"))
@@ -298,8 +297,6 @@ stats, _ := cache.Stats(ctx)  // HitCount, MissCount, HitRate
 **Get returns `(nil, nil)` on cache miss**, not an error.
 
 **Bare `"*"` patterns are rejected** by `DeletePattern` — must include agentId prefix.
-
-**Integration tests** are tagged `//go:build integration` and fail hard without Valkey. Run via `make test-integration`.
 
 Full documentation: [documentation/caching.md](../documentation/caching.md)
 
@@ -381,62 +378,34 @@ All development tasks are driven through the Makefile. The Makefile is the singl
 
 | Target | Description | Usage |
 |--------|-------------|-------|
-| `make dev` | Full dev setup: clone agency-agents, setup distrobox, install deps | First-time setup |
-| `make agent` | Enter distrobox and run OpenCode interactively | Start AI agent |
-| `make agent-stop` | Stop OpenCode in distrobox | Stop AI agent |
-| `make up` | Start all services in development mode | Start development |
-| `make down` | Stop all services | Stop development |
-| `make restart` | Restart all services | Restart services |
-| `make build` | Build all service images | Build containers |
-| `make test` | Run all tests and validate documentation | Run tests |
-| `make logs` | View logs for all services | View logs |
-| `make clean` | Remove all containers and volumes | Clean up |
-| `make ps` | Show running containers | Check status |
+| `make dev` | Setup distrobox for OpenCode | First-time setup |
+| `make agent` | Run OpenCode agent | Start AI agent |
+| `make agent-stop` | Stop OpenCode agent | Stop AI agent |
+| `make ace` | Run ACE with hot reload (backend + frontend) | Start development |
+| `make test` | Run full validation pipeline | Run tests |
 | `make help` | Show help message | Get help |
-
-### Environment Variables
-
-The Makefile supports two environment variables:
-
-- **ENVIRONMENT**: `dev` or `prod` (default: `dev`)
-- **CONTAINER_ORCHESTRATOR**: `docker` or `podman` (default: `docker`)
-
-Example usage:
-```bash
-make up ENVIRONMENT=prod CONTAINER_ORCHESTRATOR=podman
-```
 
 ### Development Environment
 
 The development environment uses:
-- **Docker Compose**: Local development with all services
+- **Single binary**: ACE with embedded SQLite, NATS, and Ristretto
 - **Distrobox**: Isolated development environment for OpenCode
 - **Pre-commit hooks**: Automated quality gates before commits
 
-Services accessible after `make up`:
-- Frontend: http://localhost:5173
+Services accessible after `make ace`:
+- Frontend: http://localhost:5173 (Vite dev server)
 - API: http://localhost:8080
-- API Docs: http://localhost:8080/docs (Swagger UI, auto-generated by Annot8)
-- PostgreSQL: localhost:5432
-- NATS: localhost:4222
-- Valkey: localhost:6379
-- Prometheus: http://localhost:9090
-- Grafana: http://localhost:3000
-- Loki: http://localhost:3100
-- Tempo: http://localhost:3200
-- OTel Collector: http://localhost:4317 (gRPC), http://localhost:4318 (HTTP)
+- API Docs: http://localhost:8080/swagger/index.html
 
 ### Testing
 
 Tests are run via `make test`, which executes:
-- Go integration tests in the API container
+- Go unit tests
+- Go integration tests with embedded services
 - Documentation validation (schema vs live DB, drift detection)
-- Frontend tests in the Frontend container
 
 The pre-commit hook runs quality gates including:
 - Go build, lint, and unit tests
-- Frontend lint and tests
-- Docker Compose validation
 - Makefile validation
 - Documentation validation (skips if no DB — flags for agent)
 
@@ -482,8 +451,9 @@ This section tracks the completion status of each design unit. Units are complet
 | **OpenCode Migration** | ✅ Complete | OpenCode integration and migration |
 | **Observability** | ✅ Complete | Observability primitives (`shared/telemetry`) |
 | **Database Design & API/DB Documentation** | ✅ Complete | Database design documentation and API/DB specification |
-| **Caching Strategies** | ✅ Complete | Valkey-backed cache with tag-based invalidation, stampede protection, warming |
+| **Caching Strategies** | ✅ Complete | Ristretto-backed in-process cache with tag-based invalidation, stampede protection, warming |
 | **Users & Auth (JWT, SSO)** | ✅ Complete | Authentication and authorization system (18 micro-PRs, all merged) |
+| **Deployment & Developer Experience (deployment-dx)** | ✅ Complete | Single binary with embedded SQLite, NATS, and Ristretto |
 | **Auditing** | 📋 Planned | Audit logging and compliance tracking |
 | **Security (Certs, TLS, HTTPS, etc)** | 📋 Planned | Security infrastructure and encryption |
 | **CI/CD (PromptFoo)** | 📋 Planned | Continuous integration and deployment pipeline |

--- a/design/units/README.md
+++ b/design/units/README.md
@@ -13,4 +13,4 @@ This directory contains discrete pieces of work: features, components, refactors
 
 ## Developer Experience
 
-- [Deployment & DX](deployment-dx/README.md) - Status: Implementation
+- [Deployment & DX](deployment-dx/README.md) - Status: Complete

--- a/documentation/auth.md
+++ b/documentation/auth.md
@@ -113,7 +113,7 @@ Recovery → Logger → CORS → RateLimit → Auth → Handler
 
 ---
 
-## Events (NATS)
+## Events
 
 | Event | Subject |
 |-------|---------|
@@ -124,6 +124,8 @@ Recovery → Logger → CORS → RateLimit → Auth → Handler
 | Role Change | `ace.auth.role_change.event` |
 | Account Suspended | `ace.auth.suspended.event` |
 | Account Deleted | `ace.auth.deleted.event` |
+
+*Events are published internally via the event bus.*
 
 ---
 

--- a/documentation/caching.md
+++ b/documentation/caching.md
@@ -1,6 +1,6 @@
 # Caching
 
-The ACE Framework uses a Valkey-backed cache library at `backend/shared/caching/`. It provides tag-based invalidation, versioned invalidation, stampede protection, bulk operations, cache warming, and observability.
+The ACE Framework uses an in-memory cache library at `backend/shared/caching/`. It provides tag-based invalidation, versioned invalidation, stampede protection, bulk operations, cache warming, and observability.
 
 ## Architecture
 
@@ -16,14 +16,11 @@ The ACE Framework uses a Valkey-backed cache library at `backend/shared/caching/
 │ (stampede)   │  (observability) │ (cache warming)   │
 ├──────────────┴──────────────────┴───────────────────┤
 │                  CacheBackend                        │
-│              (valkeyBackend)                         │
-├─────────────────────────────────────────────────────┤
-│                   Valkey / Redis                     │
-│              (ace_valkey :6379)                      │
+│              (memoryBackend)                        │
 └─────────────────────────────────────────────────────┘
 ```
 
-The `Cache` interface is the only thing services import. `CacheBackend` is an internal implementation detail — currently Valkey-only, but the interface allows future backends.
+The `Cache` interface is the only thing services import. `CacheBackend` is an internal implementation detail — currently in-memory only.
 
 ## Quick Start
 
@@ -31,13 +28,7 @@ The `Cache` interface is the only thing services import. `CacheBackend` is an in
 import "ace/shared/caching"
 
 // Create backend
-backend, err := caching.NewValkeyBackend(caching.ValkeyConfig{
-    Addr: "ace_valkey:6379",
-})
-if err != nil {
-    log.Fatal(err)
-}
-defer backend.Close()
+backend := caching.NewMemoryBackend()
 
 // Create cache
 cache := caching.NewCache(backend,
@@ -126,7 +117,7 @@ err := cache.Set(ctx, "user:123", value,
 **Constraints:**
 - Value must not be nil
 - Value size must not exceed `MaxSize` (default 1MB)
-- Tags populate the tag index (Valkey sets) for later bulk invalidation
+- Tags populate the tag index for later bulk invalidation
 
 ### Delete
 
@@ -195,19 +186,19 @@ This is the most powerful invalidation method — it deletes every key that was 
 
 ## Tag Index
 
-When you `Set` a key with tags, a bidirectional index is maintained in Valkey:
+When you `Set` a key with tags, a bidirectional index is maintained:
 
 **Forward index** (tag → keys):
 - Key: `_tags:{namespace}:{agentId}:{tag}`
-- Type: Valkey set
-- On `Set`: `SADD resolvedKey` to each tag's set
-- On `DeleteByTag`: `SMEMBERS` all keys, `DEL` each key, then `DEL` the tag set
+- Type: in-memory set
+- On `Set`: add resolvedKey to each tag's set
+- On `DeleteByTag`: get all keys, delete each key, then delete the tag set
 
 **Reverse index** (key → tags):
 - Key: `_keytags:{resolvedKey}`
-- Type: Valkey set
-- On `Set`: `SADD` all tags to this set
-- On `Delete`: `SMEMBERS` tags, `SREM` key from each tag set, `DEL` the reverse lookup
+- Type: in-memory set
+- On `Set`: add all tags to this set
+- On `Delete`: get tags, remove key from each tag set, delete the reverse lookup
 
 This ensures that when a key is deleted individually, it is removed from all tag sets it belongs to — preventing stale references.
 
@@ -254,7 +245,7 @@ taggedCache := cache.WithDefaultTags("user", "active")
 ```go
 stats, err := cache.Stats(ctx)
 // stats.HitCount, stats.MissCount, stats.HitRate
-// stats.EntryCount and stats.TotalSize are 0 (requires direct Valkey access)
+// stats.EntryCount and stats.TotalSize
 // stats.EvictionCount and stats.AvgLatencyMs are also available
 ```
 
@@ -336,7 +327,7 @@ if err != nil {
 
 **Available sentinel errors:**
 - `ErrCacheMiss` — key not found
-- `ErrBackendUnavailable` — Valkey connection failed
+- `ErrBackendUnavailable` — memory backend error
 - `ErrAgentIDMissing` — agentID required but not provided
 - `ErrInvalidKey` — key validation failed
 - `ErrTTLExpired` — TTL has expired
@@ -348,24 +339,8 @@ if err != nil {
 - `ErrSerializationFailed` — value is nil
 - `ErrPatternInvalid` — pattern is `"*"` or empty
 - `ErrTagNotFound` — tag is empty
-- `ErrNATSDisconnected` — NATS connection lost
 
 ## Configuration Reference
-
-### ValkeyConfig
-
-| Field | Default | Description |
-|-------|---------|-------------|
-| `URL` | — | Parse from URL (overrides Addr, Password, DB) |
-| `Addr` | `localhost:6379` | Valkey address |
-| `Password` | — | Authentication password |
-| `DB` | `0` | Database number |
-| `MaxRetries` | `3` | Maximum retries |
-| `DialTimeout` | `5s` | Connection timeout |
-| `ReadTimeout` | `3s` | Read timeout |
-| `WriteTimeout` | `3s` | Write timeout |
-| `PoolSize` | `100` | Connection pool size |
-| `MinIdleConns` | `10` | Minimum idle connections |
 
 ### Cache Defaults
 
@@ -376,22 +351,12 @@ if err != nil {
 | `StampedeProtection` | Enabled |
 | `InvalidationStrategy` | TTL |
 
-## Integration Tests
-
-Integration tests require a running Valkey instance and are tagged with `//go:build integration`:
+## Unit Tests
 
 ```bash
-# Run unit tests only (no Valkey needed)
+# Run unit tests only
 go test ./backend/shared/caching/... -v
-
-# Run integration tests (requires Valkey at localhost:6379)
-go test ./backend/shared/caching/... -tags=integration -v -race
-
-# Override Valkey address
-VALKEY_ADDR=valkey:6379 go test ./backend/shared/caching/... -tags=integration -v
 ```
-
-Integration tests fail hard (`t.Fatalf`) if Valkey is unavailable — they are not skipped.
 
 ## Constraints
 

--- a/documentation/dev.md
+++ b/documentation/dev.md
@@ -1,4 +1,4 @@
-# Getting Started
+# Development Guide
 
 ## Prerequisites
 
@@ -14,6 +14,11 @@
 make dev
 ```
 
+- Run ACE with hot reload
+```bash
+make ace
+```
+
 - Run the opencode agent
 ```bash
 make agent
@@ -23,15 +28,16 @@ make agent
 
 | Command | Description |
 |---------|-------------|
+| `make ace` | Run ACE with hot reload (backend + frontend) |
 | `make dev` | Setup dev environment (distrobox + agency-agents + git hooks) |
 | `make agent` | Start OpenCode in distrobox |
-| `make test` | Run all tests (API + Frontend) |
+| `make test` | Run full validation pipeline |
 | `make help` | Show available commands |
 
 ## Health Check
 
-Check API and database health:
+Check API health:
 ```bash
-curl http://localhost:8080/health/ready
-# Returns: {"checks":{<individual-component-checks>},"status":"ok"}
+curl http://localhost:8080/healthz
+# Returns: {"status":"ok"}
 ```

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -2,43 +2,49 @@
 
 ## Prerequisites
 
-- Docker or Podman
+- Git
+- Go 1.21+
+- Node.js 18+ (for frontend development)
 
-## Quick Start
+## Installation
 
-- Clone the repo
+### Install Latest Release
+
+```bash
+curl -fsSL https://ace.dev/install.sh | sh
+```
+
+### Clone for Development
+
 ```bash
 git clone https://github.com/jayfalls/ace_prototype.git
 cd ace_prototype
 ```
 
-- Run the ACE
+## Quick Start
+
+Run ACE in development mode with hot reload:
+
 ```bash
-make up
+make ace
 ```
 
 ### Make Commands
 
 | Command | Description |
 |---------|-------------|
-| `make up` | Start all services |
-| `make down` | Stop all services |
-| `make restart` | Restart all services |
-| `make logs` | View logs |
-| `make logs-api` | View API logs |
-| `make logs-fe` | View frontend logs |
-| `make logs-db` | View database logs |
-| `make logs-broker` | View broker logs |
-| `make clean` | Remove all containers and volumes |
-| `make build` | Build all images |
-| `make ps` | Show running containers |
+| `make ace` | Run ACE with hot reload (backend + frontend) |
+| `make test` | Run full validation pipeline |
+| `make dev` | Setup dev environment (distrobox + OpenCode) |
+| `make agent` | Start OpenCode agent |
 | `make help` | Show available commands |
 
 ## Services
+
+After running `make ace`:
 
 | Service | URL |
 |---------|-----|
 | Frontend | http://localhost:5173 |
 | API | http://localhost:8080 |
-| PostgreSQL | localhost:5432 |
-| NATS | localhost:4222 |
+| Swagger UI | http://localhost:8080/swagger/index.html |

--- a/documentation/observability.md
+++ b/documentation/observability.md
@@ -1,91 +1,29 @@
 # Observability
 
-The ACE Framework includes a comprehensive observability stack for monitoring traces, logs, and metrics. This document explains how to set up and use the observability features.
+The ACE Framework includes built-in observability features for tracing, logging, and metrics. This document explains the observability capabilities and optional external stack.
 
-## Overview
+## Built-in Observability
 
-The observability stack consists of:
+ACE includes telemetry built into the binary:
 
-| Component | Purpose | Port |
-|-----------|---------|------|
-| **Prometheus** | Metrics collection and storage | 9090 |
-| **Grafana** | Visualization and dashboards | 3000 |
-| **Loki** | Log aggregation | 3100 |
-| **Tempo** | Distributed tracing | 4314, 4315, 4316 |
-| **OTel Collector** | Telemetry collection and processing | 4317, 4318, 8888, 8889 |
+- **Structured Logging**: JSON logs to stdout
+- **Metrics**: Prometheus-compatible `/metrics` endpoint
+- **Tracing**: OpenTelemetry traces via OTLP
 
-## Quick Start
+### Quick Start
 
-### Starting the Observability Stack
-
-Run the following command to start all observability services:
+Run ACE and access built-in endpoints:
 
 ```bash
-cd devops/dev
-docker compose up -d prometheus otel-collector loki tempo grafana
+make ace
 ```
 
-Or start the entire stack:
+### Built-in Endpoints
 
-```bash
-cd devops/dev
-docker compose up -d
-```
-
-### Accessing the UIs
-
-| Service | URL | Credentials |
-|---------|-----|-------------|
-| Grafana | http://localhost:3000 | Anonymous (Admin) |
-| Prometheus | http://localhost:9090 | N/A |
-| Loki | http://localhost:3100 | N/A |
-| Tempo | http://localhost:4314 | N/A |
-
-## Configuring Services
-
-### OTel Collector Configuration
-
-The OTel Collector configuration is located at `devops/otel-collector-config.yaml`. It includes:
-
-- **Receivers**: OTLP (gRPC/HTTP), Filelog
-- **Exporters**: Loki (logs), Tempo (traces), Prometheus (metrics)
-- **Processors**: batch, memory_limiter, resource
-
-To modify the configuration, edit `devops/otel-collector-config.yaml` and restart the OTel Collector:
-
-```bash
-docker compose restart otel-collector
-```
-
-### Prometheus Configuration
-
-The Prometheus configuration is located at `devops/dev/prometheus.yml`. It includes scrape targets for:
-
-- Prometheus itself
-- OTel Collector
-- ACE API service
-- Loki
-- Tempo
-
-## Viewing Logs
-
-### Using Grafana
-
-1. Open Grafana at http://localhost:3000
-2. Navigate to **Explore** (compass icon)
-3. Select **Loki** as the data source
-4. Run a log query, for example:
-   - `{job="ace_api"}` - All logs from the API service
-   - `{container_name="ace_api"}` - Container-specific logs
-   - `level="error"` - Error logs only
-
-### Using Loki Directly
-
-```bash
-# Query logs using Loki API
-curl -G "http://localhost:3100/loki/api/v1/query" \
-  --data-urlencode 'query={job="ace_api"}'
-```
+| Endpoint | Description |
+|----------|-------------|
+| `GET /healthz` | Health check |
+| `GET /metrics` | Prometheus metrics |
 
 ### Log Format
 
@@ -102,66 +40,7 @@ All services output JSON logs with the following structure:
 }
 ```
 
-## Viewing Traces
-
-### Using Grafana
-
-1. Open Grafana at http://localhost:3000
-2. Navigate to **Explore** (compass icon)
-3. Select **Tempo** as the data source
-4. Search for traces by:
-   - Service name
-   - Trace ID
-   - Span name
-   - Time range
-
-### Using Tempo Directly
-
-```bash
-# Search traces
-curl -G "http://localhost:4315/api/search" \
-  --data-urlencode 'q={service.name="api"}'
-
-# Get trace by ID
-curl "http://localhost:4315/api/traces/<trace_id>"
-```
-
-### Trace Context Propagation
-
-Traces automatically propagate across services using W3C Trace Context. To view a complete trace:
-
-1. Find a trace ID from logs (look for `trace_id` field)
-2. Search in Tempo to see the full trace
-3. Click on spans to see detailed timing and attributes
-
-## Viewing Metrics
-
-### Using Prometheus
-
-1. Open Prometheus at http://localhost:9090
-2. Navigate to **Graph** or use the table view
-3. Enter a metric name, for example:
-   - `http_request_duration_seconds` - Request latency
-   - `http_requests_total` - Request count
-   - `http_active_requests` - Active requests
-
-### Using Grafana
-
-1. Open Grafana at http://localhost:3000
-2. Navigate to **Dashboards**
-3. Import or create dashboards using Prometheus as the data source
-
 ### Available Metrics
-
-The observability stack supports two metrics collection methods:
-
-#### Method 1: OTLP Push (via OTel Collector)
-Services push metrics to OTel Collector using OTLP protocol, then OTel Collector forwards to Prometheus.
-
-#### Method 2: Prometheus Pull (Direct Scraping)
-Prometheus directly scrapes metrics from service `/metrics` endpoints.
-
-#### HTTP Metrics
 
 | Metric | Type | Description |
 |--------|------|-------------|
@@ -171,13 +50,31 @@ Prometheus directly scrapes metrics from service `/metrics` endpoints.
 
 Labels: `service_name`, `method`, `path`, `status_code`
 
-#### OTel Collector Metrics
+## Optional Observability Stack
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `otelcol_exporter_sent_spans` | Counter | Number of spans exported |
-| `otelcol_exporter_sent_metric_points` | Counter | Number of metric points exported |
-| `otelcol_receiver_accepted_spans` | Counter | Number of spans received |
+For advanced monitoring, an optional external stack can be deployed separately:
+
+```bash
+cd devops/dev
+docker compose up -d prometheus otel-collector loki tempo grafana
+```
+
+| Component | Purpose | Port |
+|-----------|---------|------|
+| **Prometheus** | Metrics collection and storage | 9090 |
+| **Grafana** | Visualization and dashboards | 3000 |
+| **Loki** | Log aggregation | 3100 |
+| **Tempo** | Distributed tracing | 4314, 4315, 4316 |
+| **OTel Collector** | Telemetry collection and processing | 4317, 4318, 8888, 8889 |
+
+### Accessing UIs
+
+| Service | URL | Credentials |
+|---------|-----|-------------|
+| Grafana | http://localhost:3000 | Anonymous (Admin) |
+| Prometheus | http://localhost:9090 | N/A |
+| Loki | http://localhost:3100 | N/A |
+| Tempo | http://localhost:4314 | N/A |
 
 ## Application Integration
 


### PR DESCRIPTION
## Summary
- Update Architecture section: Replace Docker Compose topology diagram with single binary architecture description (SQLite, embedded NATS, Ristretto)
- Update Development Workflow section: Replace Docker-based Makefile targets with single binary targets (`make ace`, `make run`)
- Add deployment-dx to Completed Units table
- Update caching documentation to reflect Ristretto instead of Valkey
- Update units/README.md status from "Implementation" to "Complete"

## Changes
- **Architecture**: Single binary with embedded subsystems replaces separate container topology
- **Makefile targets**: Docker commands replaced with `make ace` and `make run`
- **Caching**: Valkey references replaced with Ristretto (in-process)
- **Observability**: External OTel pipeline replaced with SQLite-backed telemetry