### PR TITLE
[unit: frontend-design] Slice 2: API Client & Auth Store

### DIFF
--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -1,0 +1,87 @@
+import { apiClient } from './client';
+import type {
+	LoginRequest,
+	RegisterRequest,
+	TokenResponse,
+	User,
+	ResetPasswordRequest,
+	MagicLinkVerifyRequest
+} from './types';
+
+export async function login(email: string, password: string): Promise<TokenResponse> {
+	return apiClient.request<TokenResponse>({
+		method: 'POST',
+		path: '/auth/login',
+		body: { email, password } satisfies LoginRequest,
+		requiresAuth: false
+	});
+}
+
+export async function register(email: string, password: string): Promise<TokenResponse> {
+	return apiClient.request<TokenResponse>({
+		method: 'POST',
+		path: '/auth/register',
+		body: { email, password } satisfies RegisterRequest,
+		requiresAuth: false
+	});
+}
+
+export async function logout(sessionId: string): Promise<void> {
+	return apiClient.request<void>({
+		method: 'POST',
+		path: '/auth/logout',
+		body: { session_id: sessionId }
+	});
+}
+
+export async function refresh(refreshToken: string): Promise<TokenResponse> {
+	return apiClient.request<TokenResponse>({
+		method: 'POST',
+		path: '/auth/refresh',
+		body: { refresh_token: refreshToken },
+		requiresAuth: false
+	});
+}
+
+export async function me(): Promise<User> {
+	return apiClient.request<User>({
+		method: 'GET',
+		path: '/auth/me'
+	});
+}
+
+export async function resetPasswordRequest(email: string): Promise<void> {
+	return apiClient.request<void>({
+		method: 'POST',
+		path: '/auth/password/reset/request',
+		body: { email },
+		requiresAuth: false
+	});
+}
+
+export async function resetPasswordConfirm(token: string, newPassword: string): Promise<TokenResponse> {
+	return apiClient.request<TokenResponse>({
+		method: 'POST',
+		path: '/auth/password/reset/confirm',
+		body: { token, new_password: newPassword } satisfies ResetPasswordRequest,
+		requiresAuth: false
+	});
+}
+
+export async function magicLinkRequest(email: string): Promise<void> {
+	return apiClient.request<void>({
+		method: 'POST',
+		path: '/auth/magic-link/request',
+		body: { email },
+		requiresAuth: false
+	});
+}
+
+export async function magicLinkVerify(token: string): Promise<TokenResponse> {
+	return apiClient.request<TokenResponse>({
+		method: 'POST',
+		path: '/auth/magic-link/verify',
+		body: { token } satisfies MagicLinkVerifyRequest,
+		requiresAuth: false
+	});
+}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,0 +1,208 @@
+import type { APIEnvelope, APIError } from './types';
+import { AUTH } from '$lib/utils/constants';
+
+export interface RequestOptions {
+	method: string;
+	path: string;
+	body?: unknown;
+	requiresAuth?: boolean;
+}
+
+const ERROR_CODE_MAP: Record<number, string> = {
+	400: 'invalid_request',
+	401: 'unauthorized',
+	403: 'forbidden',
+	404: 'not_found',
+	409: 'user_already_exists',
+	429: 'rate_limit_exceeded',
+	500: 'internal_error'
+};
+
+class APIClient {
+	private baseUrl: string;
+	private refreshPromise: Promise<void> | null = null;
+	private accessToken = '';
+	private refreshToken = '';
+	private expiresAt = 0;
+
+	constructor() {
+		this.baseUrl = '/api';
+	}
+
+	private getAccessToken(): string | null {
+		if (!this.accessToken || Date.now() >= this.expiresAt) {
+			return null;
+		}
+		return this.accessToken;
+	}
+
+	private setTokens(access: string, refresh: string, expiresIn: number): void {
+		this.accessToken = access;
+		this.refreshToken = refresh;
+		this.expiresAt = Date.now() + expiresIn * 1000;
+	}
+
+	private clearTokens(): void {
+		this.accessToken = '';
+		this.refreshToken = '';
+		this.expiresAt = 0;
+	}
+
+	// Called by auth store to restore tokens
+	setStoredTokens(access: string, refresh: string, expiresAt: number): void {
+		this.accessToken = access;
+		this.refreshToken = refresh;
+		this.expiresAt = expiresAt;
+	}
+
+	// Called by auth store to clear tokens
+	clearStoredTokens(): void {
+		this.clearTokens();
+	}
+
+	// Called by auth store to update tokens after refresh
+	updateTokens(access: string, refresh: string, expiresIn: number): void {
+		this.setTokens(access, refresh, expiresIn);
+	}
+
+	private async ensureValidToken(): Promise<void> {
+		const remaining = this.expiresAt - Date.now();
+		if (remaining < AUTH.REFRESH_THRESHOLD_MS && this.refreshToken) {
+			await this.handleUnauthorized();
+		}
+	}
+
+	private async handleUnauthorized(): Promise<void> {
+		// Refresh mutex: if already refreshing, await that promise
+		if (this.refreshPromise) {
+			await this.refreshPromise;
+			return;
+		}
+
+		if (!this.refreshToken) {
+			throw new Error('No refresh token available');
+		}
+
+		this.refreshPromise = this.doRefresh();
+		try {
+			await this.refreshPromise;
+		} finally {
+			this.refreshPromise = null;
+		}
+	}
+
+	private async doRefresh(): Promise<void> {
+		const response = await fetch(`${this.baseUrl}/auth/refresh`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ refresh_token: this.refreshToken })
+		});
+
+		if (!response.ok) {
+			this.clearTokens();
+			throw await this.normalizeError(response);
+		}
+
+		const envelope = await response.json() as APIEnvelope<{
+			access_token: string;
+			refresh_token: string;
+			expires_in: number;
+		}>;
+
+		if (!envelope.success || !envelope.data) {
+			this.clearTokens();
+			throw new Error(envelope.error?.message ?? 'Refresh failed');
+		}
+
+		const { access_token, refresh_token, expires_in } = envelope.data;
+		this.setTokens(access_token, refresh_token, expires_in);
+	}
+
+	private async normalizeError(response: Response): Promise<APIError> {
+		let error: APIError;
+
+		try {
+			const envelope = await response.json() as APIEnvelope<null>;
+			if (envelope.error) {
+				error = envelope.error;
+			} else {
+				error = {
+					code: ERROR_CODE_MAP[response.status] ?? 'internal_error',
+					message: `HTTP ${response.status}`
+				};
+			}
+		} catch {
+			error = {
+				code: ERROR_CODE_MAP[response.status] ?? 'internal_error',
+				message: `HTTP ${response.status}`
+			};
+		}
+
+		return error;
+	}
+
+	async request<T>(options: RequestOptions): Promise<T> {
+		const { method, path, body, requiresAuth = true } = options;
+
+		// Proactive refresh: if token expires soon, refresh first
+		if (requiresAuth) {
+			await this.ensureValidToken();
+		}
+
+		const headers: Record<string, string> = {
+			'Content-Type': 'application/json'
+		};
+
+		if (requiresAuth) {
+			const token = this.getAccessToken();
+			if (token) {
+				headers['Authorization'] = `Bearer ${token}`;
+			}
+		}
+
+		const response = await fetch(`${this.baseUrl}${path}`, {
+			method,
+			headers,
+			body: body ? JSON.stringify(body) : undefined
+		});
+
+		// Handle 401 with reactive refresh
+		if (response.status === 401 && requiresAuth) {
+			await this.handleUnauthorized();
+			// Retry original request
+			const token = this.getAccessToken();
+			if (token) {
+				headers['Authorization'] = `Bearer ${token}`;
+			}
+			const retryResponse = await fetch(`${this.baseUrl}${path}`, {
+				method,
+				headers,
+				body: body ? JSON.stringify(body) : undefined
+			});
+
+			if (!retryResponse.ok) {
+				throw await this.normalizeError(retryResponse);
+			}
+
+			const envelope = await retryResponse.json() as APIEnvelope<T>;
+			if (!envelope.success) {
+				throw envelope.error ?? { code: 'internal_error', message: 'Request failed' };
+			}
+			return envelope.data as T;
+		}
+
+		if (!response.ok) {
+			throw await this.normalizeError(response);
+		}
+
+		const envelope = await response.json() as APIEnvelope<T>;
+
+		if (!envelope.success) {
+			throw envelope.error ?? { code: 'internal_error', message: 'Request failed' };
+		}
+
+		return envelope.data as T;
+	}
+}
+
+export const apiClient = new APIClient();

--- a/frontend/src/lib/api/sessions.ts
+++ b/frontend/src/lib/api/sessions.ts
@@ -1,0 +1,16 @@
+import { apiClient } from './client';
+import type { SessionsListResponse } from './types';
+
+export async function listSessions(page = 1, limit = 20): Promise<SessionsListResponse> {
+	return apiClient.request<SessionsListResponse>({
+		method: 'GET',
+		path: `/auth/me/sessions?page=${page}&limit=${limit}`
+	});
+}
+
+export async function revokeSession(sessionId: string): Promise<void> {
+	return apiClient.request<void>({
+		method: 'DELETE',
+		path: `/auth/me/sessions/${sessionId}`
+	});
+}

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -1,0 +1,232 @@
+// --- API Envelope ---
+export interface APIEnvelope<T> {
+	success: boolean;
+	data?: T;
+	error?: APIError;
+}
+
+export interface APIError {
+	code: string;
+	message: string;
+	details?: FieldError[];
+}
+
+export interface FieldError {
+	field: string;
+	message: string;
+}
+
+// --- Pagination ---
+export interface PaginatedResponse<T> {
+	items: T[];
+	total: number;
+	page: number;
+	limit: number;
+}
+
+// --- Auth ---
+export interface LoginRequest {
+	email: string;
+	password: string;
+}
+
+export interface RegisterRequest {
+	email: string;
+	password: string;
+}
+
+export interface TokenResponse {
+	access_token: string;
+	refresh_token: string;
+	user: User;
+	expires_in: number;
+}
+
+export interface RefreshRequest {
+	refresh_token: string;
+}
+
+export interface ResetPasswordRequest {
+	token: string;
+	new_password: string;
+}
+
+export interface MagicLinkVerifyRequest {
+	token: string;
+}
+
+// --- User ---
+export type UserRole = 'admin' | 'user' | 'viewer';
+export type UserStatus = 'pending' | 'active' | 'suspended';
+
+export interface User {
+	id: string;
+	email: string;
+	role: UserRole;
+	status: UserStatus;
+	suspended_at?: string;
+	suspended_reason?: string;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface UserListItem {
+	id: string;
+	email: string;
+	role: UserRole;
+	status: UserStatus;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface AdminUserResponse {
+	id: string;
+	email: string;
+	role: UserRole;
+	status: UserStatus;
+	suspended_at?: string;
+	suspended_reason?: string;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface UsersListResponse {
+	users: UserListItem[];
+	total: number;
+	page: number;
+	limit: number;
+}
+
+// --- Sessions ---
+export interface Session {
+	id: string;
+	user_id: string;
+	user_agent?: string;
+	ip_address?: string;
+	last_used_at: string;
+	expires_at: string;
+	created_at: string;
+}
+
+export interface SessionsListResponse {
+	sessions: Session[];
+	total: number;
+	page: number;
+	limit: number;
+}
+
+// --- Telemetry: Spans ---
+export interface Span {
+	trace_id: string;
+	span_id: string;
+	operation: string;
+	service: string;
+	start_time: string;
+	end_time: string;
+	duration_ms: number;
+	status: string;
+	attributes?: Record<string, unknown>;
+}
+
+export interface SpansResponse {
+	spans: Span[];
+	total: number;
+	limit: number;
+	offset: number;
+}
+
+// --- Telemetry: Metrics ---
+export interface Metric {
+	name: string;
+	type: string;
+	labels?: Record<string, string>;
+	value: number;
+	timestamp: string;
+	window?: string;
+}
+
+export interface MetricsResponse {
+	metrics: Metric[];
+	total: number;
+	limit: number;
+}
+
+// --- Telemetry: Usage ---
+export interface UsageEvent {
+	id: string;
+	agent_id: string;
+	session_id: string;
+	event_type: string;
+	model?: string;
+	input_tokens?: number;
+	output_tokens?: number;
+	cost_usd?: number;
+	duration_ms?: number;
+	timestamp: string;
+}
+
+export interface UsageResponse {
+	events: UsageEvent[];
+	total: number;
+	limit: number;
+	offset: number;
+}
+
+// --- Telemetry: Health ---
+export type HealthStatus = 'healthy' | 'degraded' | 'error';
+
+export interface SubsystemCheck {
+	status: string;
+	mode?: string;
+	path?: string;
+	size_bytes?: number;
+	connections?: number;
+	max_cost_bytes?: number;
+	current_cost_bytes?: number;
+	hit_rate?: number;
+	spans_last_hour?: number;
+	metrics_last_hour?: number;
+	error?: string;
+}
+
+export interface TelemetryHealthResponse {
+	status: HealthStatus;
+	checks: Record<string, SubsystemCheck>;
+}
+
+// --- Health ---
+export interface SystemHealthCheck {
+	status: string;
+	reason?: string;
+}
+
+export interface SystemHealthResponse {
+	status: string;
+	checks: Record<string, SystemHealthCheck>;
+}
+
+// --- Query Params ---
+export interface SpanQueryParams {
+	service?: string;
+	operation?: string;
+	status?: string;
+	start_time?: string;
+	end_time?: string;
+	limit?: number;
+	offset?: number;
+}
+
+export interface MetricQueryParams {
+	name?: string;
+	window?: '5m' | '15m' | '1h' | '6h' | '24h';
+	limit?: number;
+}
+
+export interface UsageQueryParams {
+	agent_id?: string;
+	event_type?: string;
+	from?: string;
+	to?: string;
+	limit?: number;
+	offset?: number;
+}

--- a/frontend/src/lib/stores/auth.svelte.ts
+++ b/frontend/src/lib/stores/auth.svelte.ts
@@ -1,0 +1,156 @@
+import { goto } from '$app/navigation';
+import * as authApi from '$lib/api/auth';
+import { apiClient } from '$lib/api/client';
+import type { User, TokenResponse } from '$lib/api/types';
+import { AUTH, ROUTES } from '$lib/utils/constants';
+
+class AuthStore {
+	user = $state<User | null>(null);
+	accessToken = $state<string>('');
+	refreshToken = $state<string>('');
+	expiresAt = $state<number>(0);
+	isLoading = $state<boolean>(false);
+	error = $state<string | null>(null);
+
+	isAuthenticated = $derived(this.user !== null && this.accessToken !== '');
+
+	private setTokens(access: string, refresh: string, expiresIn: number): void {
+		this.accessToken = access;
+		this.refreshToken = refresh;
+		this.expiresAt = Date.now() + expiresIn * 1000;
+		apiClient.updateTokens(access, refresh, expiresIn);
+		this.persistToStorage();
+	}
+
+	private persistToStorage(): void {
+		if (typeof localStorage === 'undefined') return;
+		localStorage.setItem(AUTH.LOCALSTORAGE_ACCESS_TOKEN, this.accessToken);
+		localStorage.setItem(AUTH.LOCALSTORAGE_REFRESH_TOKEN, this.refreshToken);
+		localStorage.setItem(AUTH.LOCALSTORAGE_EXPIRES_AT, String(this.expiresAt));
+	}
+
+	private clearStorage(): void {
+		if (typeof localStorage === 'undefined') return;
+		localStorage.removeItem(AUTH.LOCALSTORAGE_ACCESS_TOKEN);
+		localStorage.removeItem(AUTH.LOCALSTORAGE_REFRESH_TOKEN);
+		localStorage.removeItem(AUTH.LOCALSTORAGE_EXPIRES_AT);
+	}
+
+	init(): void {
+		if (typeof localStorage === 'undefined') return;
+		const access = localStorage.getItem(AUTH.LOCALSTORAGE_ACCESS_TOKEN) ?? '';
+		const refresh = localStorage.getItem(AUTH.LOCALSTORAGE_REFRESH_TOKEN) ?? '';
+		const expiresAt = parseInt(localStorage.getItem(AUTH.LOCALSTORAGE_EXPIRES_AT) ?? '0', 10);
+
+		if (!access || !refresh || !expiresAt) return;
+
+		// If expired, attempt refresh
+		if (Date.now() >= expiresAt) {
+			this.accessToken = access;
+			this.refreshToken = refresh;
+			this.expiresAt = expiresAt;
+			apiClient.setStoredTokens(access, refresh, expiresAt);
+			this.refreshTokens().catch(() => this.clear());
+			return;
+		}
+
+		this.accessToken = access;
+		this.refreshToken = refresh;
+		this.expiresAt = expiresAt;
+		apiClient.setStoredTokens(access, refresh, expiresAt);
+
+		// Fetch user data
+		this.isLoading = true;
+		authApi
+			.me()
+			.then((user) => {
+				this.user = user;
+			})
+			.catch(() => {
+				this.clear();
+			})
+			.finally(() => {
+				this.isLoading = false;
+			});
+	}
+
+	async login(email: string, password: string): Promise<void> {
+		this.isLoading = true;
+		this.error = null;
+		try {
+			const response = await authApi.login(email, password);
+			this.handleTokenResponse(response);
+		} catch (err) {
+			this.error = err instanceof Error ? err.message : 'Login failed';
+			throw err;
+		} finally {
+			this.isLoading = false;
+		}
+	}
+
+	async register(email: string, password: string): Promise<void> {
+		this.isLoading = true;
+		this.error = null;
+		try {
+			const response = await authApi.register(email, password);
+			this.handleTokenResponse(response);
+		} catch (err) {
+			this.error = err instanceof Error ? err.message : 'Registration failed';
+			throw err;
+		} finally {
+			this.isLoading = false;
+		}
+	}
+
+	async logout(): Promise<void> {
+		try {
+			await authApi.logout(this.refreshToken);
+		} catch {
+			// Ignore logout errors, clear state anyway
+		} finally {
+			this.clear();
+			goto(ROUTES.LOGIN);
+		}
+	}
+
+	async refreshTokens(): Promise<void> {
+		if (!this.refreshToken) {
+			this.clear();
+			goto(ROUTES.LOGIN);
+			return;
+		}
+
+		try {
+			const response = await authApi.refresh(this.refreshToken);
+			this.handleTokenResponse(response);
+		} catch {
+			this.clear();
+			goto(ROUTES.LOGIN);
+			throw new Error('Token refresh failed');
+		}
+	}
+
+	async ensureValidToken(): Promise<void> {
+		const remaining = this.expiresAt - Date.now();
+		if (remaining < AUTH.REFRESH_THRESHOLD_MS) {
+			await this.refreshTokens();
+		}
+	}
+
+	clear(): void {
+		this.user = null;
+		this.accessToken = '';
+		this.refreshToken = '';
+		this.expiresAt = 0;
+		this.error = null;
+		this.clearStorage();
+		apiClient.clearStoredTokens();
+	}
+
+	private handleTokenResponse(response: TokenResponse): void {
+		this.user = response.user;
+		this.setTokens(response.access_token, response.refresh_token, response.expires_in);
+	}
+}
+
+export const authStore = new AuthStore();

--- a/frontend/src/lib/stores/notifications.svelte.ts
+++ b/frontend/src/lib/stores/notifications.svelte.ts
@@ -1,0 +1,61 @@
+export interface Toast {
+	id: string;
+	variant: 'success' | 'error' | 'warning' | 'info';
+	title: string;
+	description?: string;
+	duration: number;
+	createdAt: number;
+}
+
+class NotificationStore {
+	toasts = $state<Toast[]>([]);
+
+	add(
+		title: string,
+		variant: Toast['variant'] = 'info',
+		description?: string,
+		duration: number = 5000
+	): string {
+		const id = crypto.randomUUID();
+		const toast: Toast = {
+			id,
+			variant,
+			title,
+			description,
+			duration,
+			createdAt: Date.now()
+		};
+		this.toasts.push(toast);
+
+		if (duration > 0) {
+			setTimeout(() => this.dismiss(id), duration);
+		}
+
+		return id;
+	}
+
+	dismiss(id: string): void {
+		const index = this.toasts.findIndex((t) => t.id === id);
+		if (index !== -1) {
+			this.toasts.splice(index, 1);
+		}
+	}
+
+	success(title: string, description?: string): string {
+		return this.add(title, 'success', description);
+	}
+
+	error(title: string, description?: string): string {
+		return this.add(title, 'error', description, 8000);
+	}
+
+	warning(title: string, description?: string): string {
+		return this.add(title, 'warning', description);
+	}
+
+	info(title: string, description?: string): string {
+		return this.add(title, 'info', description);
+	}
+}
+
+export const notificationStore = new NotificationStore();

--- a/frontend/src/test/api/auth.test.ts
+++ b/frontend/src/test/api/auth.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock dependencies
+vi.mock('$lib/api/client', () => ({
+	apiClient: {
+		request: vi.fn()
+	}
+}));
+
+describe('Auth API', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('login', () => {
+		it('calls POST /auth/login with email and password', async () => {
+			const { apiClient } = await import('$lib/api/client');
+			const { login } = await import('$lib/api/auth');
+
+			vi.mocked(apiClient.request).mockResolvedValue({
+				access_token: 'token',
+				refresh_token: 'refresh',
+				user: { id: '1', email: 'test@test.com', role: 'user', status: 'active', created_at: '', updated_at: '' },
+				expires_in: 3600
+			});
+
+			const result = await login('test@test.com', 'password123');
+
+			expect(apiClient.request).toHaveBeenCalledWith({
+				method: 'POST',
+				path: '/auth/login',
+				body: { email: 'test@test.com', password: 'password123' },
+				requiresAuth: false
+			});
+			expect(result.access_token).toBe('token');
+		});
+	});
+
+	describe('register', () => {
+		it('calls POST /auth/register with email and password', async () => {
+			const { apiClient } = await import('$lib/api/client');
+			const { register } = await import('$lib/api/auth');
+
+			vi.mocked(apiClient.request).mockResolvedValue({
+				access_token: 'token',
+				refresh_token: 'refresh',
+				user: { id: '1', email: 'new@test.com', role: 'user', status: 'active', created_at: '', updated_at: '' },
+				expires_in: 3600
+			});
+
+			const result = await register('new@test.com', 'password123');
+
+			expect(apiClient.request).toHaveBeenCalledWith({
+				method: 'POST',
+				path: '/auth/register',
+				body: { email: 'new@test.com', password: 'password123' },
+				requiresAuth: false
+			});
+			expect(result.user.email).toBe('new@test.com');
+		});
+	});
+
+	describe('logout', () => {
+		it('calls POST /auth/logout with session_id', async () => {
+			const { apiClient } = await import('$lib/api/client');
+			const { logout } = await import('$lib/api/auth');
+
+			vi.mocked(apiClient.request).mockResolvedValue(undefined);
+
+			await logout('session-123');
+
+			expect(apiClient.request).toHaveBeenCalledWith({
+				method: 'POST',
+				path: '/auth/logout',
+				body: { session_id: 'session-123' }
+			});
+		});
+	});
+
+	describe('refresh', () => {
+		it('calls POST /auth/refresh with refresh_token', async () => {
+			const { apiClient } = await import('$lib/api/client');
+			const { refresh } = await import('$lib/api/auth');
+
+			vi.mocked(apiClient.request).mockResolvedValue({
+				access_token: 'new-token',
+				refresh_token: 'new-refresh',
+				user: { id: '1', email: 'test@test.com', role: 'user', status: 'active', created_at: '', updated_at: '' },
+				expires_in: 3600
+			});
+
+			const result = await refresh('old-refresh-token');
+
+			expect(apiClient.request).toHaveBeenCalledWith({
+				method: 'POST',
+				path: '/auth/refresh',
+				body: { refresh_token: 'old-refresh-token' },
+				requiresAuth: false
+			});
+			expect(result.access_token).toBe('new-token');
+		});
+	});
+
+	describe('me', () => {
+		it('calls GET /auth/me', async () => {
+			const { apiClient } = await import('$lib/api/client');
+			const { me } = await import('$lib/api/auth');
+
+			const mockUser = {
+				id: '1',
+				email: 'test@test.com',
+				role: 'user' as const,
+				status: 'active' as const,
+				created_at: '2024-01-01T00:00:00Z',
+				updated_at: '2024-01-01T00:00:00Z'
+			};
+			vi.mocked(apiClient.request).mockResolvedValue(mockUser);
+
+			const result = await me();
+
+			expect(apiClient.request).toHaveBeenCalledWith({
+				method: 'GET',
+				path: '/auth/me'
+			});
+			expect(result.email).toBe('test@test.com');
+		});
+	});
+
+	describe('resetPasswordRequest', () => {
+		it('calls POST /auth/password/reset/request with email', async () => {
+			const { apiClient } = await import('$lib/api/client');
+			const { resetPasswordRequest } = await import('$lib/api/auth');
+
+			vi.mocked(apiClient.request).mockResolvedValue(undefined);
+
+			await resetPasswordRequest('test@test.com');
+
+			expect(apiClient.request).toHaveBeenCalledWith({
+				method: 'POST',
+				path: '/auth/password/reset/request',
+				body: { email: 'test@test.com' },
+				requiresAuth: false
+			});
+		});
+	});
+
+	describe('resetPasswordConfirm', () => {
+		it('calls POST /auth/password/reset/confirm with token and new_password', async () => {
+			const { apiClient } = await import('$lib/api/client');
+			const { resetPasswordConfirm } = await import('$lib/api/auth');
+
+			vi.mocked(apiClient.request).mockResolvedValue({
+				access_token: 'token',
+				refresh_token: 'refresh',
+				user: { id: '1', email: 'test@test.com', role: 'user', status: 'active', created_at: '', updated_at: '' },
+				expires_in: 3600
+			});
+
+			const result = await resetPasswordConfirm('reset-token-xyz', 'newpassword123');
+
+			expect(apiClient.request).toHaveBeenCalledWith({
+				method: 'POST',
+				path: '/auth/password/reset/confirm',
+				body: { token: 'reset-token-xyz', new_password: 'newpassword123' },
+				requiresAuth: false
+			});
+			expect(result.access_token).toBe('token');
+		});
+	});
+
+	describe('magicLinkRequest', () => {
+		it('calls POST /auth/magic-link/request with email', async () => {
+			const { apiClient } = await import('$lib/api/client');
+			const { magicLinkRequest } = await import('$lib/api/auth');
+
+			vi.mocked(apiClient.request).mockResolvedValue(undefined);
+
+			await magicLinkRequest('test@test.com');
+
+			expect(apiClient.request).toHaveBeenCalledWith({
+				method: 'POST',
+				path: '/auth/magic-link/request',
+				body: { email: 'test@test.com' },
+				requiresAuth: false
+			});
+		});
+	});
+
+	describe('magicLinkVerify', () => {
+		it('calls POST /auth/magic-link/verify with token', async () => {
+			const { apiClient } = await import('$lib/api/client');
+			const { magicLinkVerify } = await import('$lib/api/auth');
+
+			vi.mocked(apiClient.request).mockResolvedValue({
+				access_token: 'token',
+				refresh_token: 'refresh',
+				user: { id: '1', email: 'test@test.com', role: 'user', status: 'active', created_at: '', updated_at: '' },
+				expires_in: 3600
+			});
+
+			const result = await magicLinkVerify('magic-token-xyz');
+
+			expect(apiClient.request).toHaveBeenCalledWith({
+				method: 'POST',
+				path: '/auth/magic-link/verify',
+				body: { token: 'magic-token-xyz' },
+				requiresAuth: false
+			});
+			expect(result.access_token).toBe('token');
+		});
+	});
+});

--- a/frontend/src/test/api/client.test.ts
+++ b/frontend/src/test/api/client.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the constants module
+vi.mock('$lib/utils/constants', () => ({
+	AUTH: {
+		REFRESH_THRESHOLD_MS: 30_000,
+		LOCALSTORAGE_ACCESS_TOKEN: 'ace_access_token',
+		LOCALSTORAGE_REFRESH_TOKEN: 'ace_refresh_token',
+		LOCALSTORAGE_EXPIRES_AT: 'ace_expires_at'
+	}
+}));
+
+describe('APIClient', () => {
+	let apiClient: {
+		request: <T>(options: {
+			method: string;
+			path: string;
+			body?: unknown;
+			requiresAuth?: boolean;
+		}) => Promise<T>;
+		setStoredTokens: (access: string, refresh: string, expiresAt: number) => void;
+		clearStoredTokens: () => void;
+		updateTokens: (access: string, refresh: string, expiresIn: number) => void;
+	};
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		const { apiClient: client } = await import('$lib/api/client');
+		apiClient = client as unknown as typeof apiClient;
+	});
+
+	describe('token injection', () => {
+		it('injects bearer token on authenticated requests', async () => {
+			apiClient.setStoredTokens('test-access', 'test-refresh', Date.now() + 60_000);
+
+			const mockFetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: () => Promise.resolve({ success: true, data: { test: true } })
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			await apiClient.request({ method: 'GET', path: '/test', requiresAuth: true });
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				'/api/test',
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: 'Bearer test-access'
+					})
+				})
+			);
+		});
+
+		it('does not inject token on unauthenticated requests', async () => {
+			const mockFetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: () => Promise.resolve({ success: true, data: { test: true } })
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			await apiClient.request({ method: 'POST', path: '/auth/login', requiresAuth: false });
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				'/api/auth/login',
+				expect.objectContaining({
+					headers: expect.not.objectContaining({
+						Authorization: expect.any(String)
+					})
+				})
+			);
+		});
+	});
+
+	describe('401 refresh', () => {
+		it('triggers token refresh on 401 response', async () => {
+			const now = Date.now();
+			apiClient.setStoredTokens('old-access', 'test-refresh', now + 60_000);
+
+			const mockFetch = vi
+				.fn()
+				.mockResolvedValueOnce({
+					ok: false,
+					status: 401,
+					json: () => Promise.resolve({ success: false, error: { code: 'unauthorized', message: 'Expired' } })
+				})
+				.mockResolvedValueOnce({
+					ok: true,
+					json: () =>
+						Promise.resolve({
+							success: true,
+							data: { access_token: 'new-access', refresh_token: 'new-refresh', expires_in: 3600 }
+						})
+				})
+				.mockResolvedValueOnce({
+					ok: true,
+					json: () => Promise.resolve({ success: true, data: { test: true } })
+				});
+			vi.stubGlobal('fetch', mockFetch);
+
+			const result = await apiClient.request({ method: 'GET', path: '/test', requiresAuth: true });
+
+			expect(mockFetch).toHaveBeenCalledTimes(3);
+			expect(result).toEqual({ test: true });
+		});
+
+		it('clears tokens and throws on refresh failure after 401', async () => {
+			const now = Date.now();
+			apiClient.setStoredTokens('old-access', 'bad-refresh', now + 60_000);
+
+			const mockFetch = vi
+				.fn()
+				.mockResolvedValueOnce({
+					ok: false,
+					status: 401,
+					json: () => Promise.resolve({ success: false, error: { code: 'unauthorized', message: 'Expired' } })
+				})
+				.mockResolvedValueOnce({
+					ok: false,
+					status: 401,
+					json: () => Promise.resolve({ success: false, error: { code: 'unauthorized', message: 'Invalid' } })
+				});
+			vi.stubGlobal('fetch', mockFetch);
+
+			await expect(
+				apiClient.request({ method: 'GET', path: '/test', requiresAuth: true })
+			).rejects.toThrow();
+		});
+	});
+
+	describe('refresh mutex', () => {
+		it('blocks concurrent refresh attempts to single promise', async () => {
+			const now = Date.now();
+			apiClient.setStoredTokens('old-access', 'test-refresh', now + 60_000);
+
+			let refreshCount = 0;
+			const mockFetch = vi.fn().mockImplementation(() => {
+				if (refreshCount === 0) {
+					// First call: 401
+					refreshCount++;
+					return Promise.resolve({
+						ok: false,
+						status: 401,
+						json: () =>
+							Promise.resolve({
+								success: false,
+								error: { code: 'unauthorized', message: 'Expired' }
+							})
+					});
+				} else if (refreshCount === 1) {
+					// Second call: refresh response
+					refreshCount++;
+					return Promise.resolve({
+						ok: true,
+						json: () =>
+							Promise.resolve({
+								success: true,
+								data: {
+									access_token: 'new-access',
+									refresh_token: 'new-refresh',
+									expires_in: 3600
+								}
+							})
+					});
+				} else {
+					// Third call: successful retry
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ success: true, data: { ok: true } })
+					});
+				}
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			// Make two concurrent requests that will both trigger 401
+			const [req1, req2] = await Promise.allSettled([
+				apiClient.request({ method: 'GET', path: '/test', requiresAuth: true }),
+				apiClient.request({ method: 'GET', path: '/test2', requiresAuth: true })
+			]);
+
+			// Only one refresh should have occurred
+			expect(refreshCount).toBe(2); // 401 + refresh response
+			expect(req1.status).toBe('fulfilled');
+			expect(req2.status).toBe('fulfilled');
+		});
+	});
+
+	describe('error mapping', () => {
+		it('maps error codes from envelope', async () => {
+			const mockFetch = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 400,
+				json: () =>
+					Promise.resolve({
+						success: false,
+						error: { code: 'validation_error', message: 'Invalid input' }
+					})
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			await expect(
+				apiClient.request({ method: 'POST', path: '/test', body: {}, requiresAuth: false })
+			).rejects.toMatchObject({ code: 'validation_error', message: 'Invalid input' });
+		});
+
+		it('maps HTTP status to error codes', async () => {
+			const mockFetch = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 404,
+				json: () => Promise.resolve({})
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			await expect(
+				apiClient.request({ method: 'GET', path: '/notfound', requiresAuth: false })
+			).rejects.toMatchObject({ code: 'not_found' });
+		});
+	});
+
+	describe('envelope unwrapping', () => {
+		it('returns data from successful envelope', async () => {
+			const mockFetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: () => Promise.resolve({ success: true, data: { id: '123', name: 'test' } })
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			const result = await apiClient.request<{ id: string; name: string }>({
+				method: 'GET',
+				path: '/test',
+				requiresAuth: false
+			});
+
+			expect(result).toEqual({ id: '123', name: 'test' });
+		});
+
+		it('throws when success is false in envelope', async () => {
+			const mockFetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: () =>
+					Promise.resolve({
+						success: false,
+						error: { code: 'invalid_request', message: 'Bad request' }
+					})
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			await expect(
+				apiClient.request({ method: 'POST', path: '/test', body: {}, requiresAuth: false })
+			).rejects.toMatchObject({ code: 'invalid_request', message: 'Bad request' });
+		});
+	});
+});

--- a/frontend/src/test/stores/auth.svelte.test.ts
+++ b/frontend/src/test/stores/auth.svelte.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock modules before importing the store
+vi.mock('$lib/api/auth', () => ({
+	login: vi.fn(),
+	register: vi.fn(),
+	logout: vi.fn(),
+	refresh: vi.fn(),
+	me: vi.fn()
+}));
+
+vi.mock('$lib/api/client', () => ({
+	apiClient: {
+		setStoredTokens: vi.fn(),
+		clearStoredTokens: vi.fn(),
+		updateTokens: vi.fn()
+	}
+}));
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn()
+}));
+
+describe('AuthStore', () => {
+	let authStore: {
+		user: unknown;
+		accessToken: unknown;
+		refreshToken: unknown;
+		expiresAt: unknown;
+		isLoading: unknown;
+		error: unknown;
+		isAuthenticated: unknown;
+		login: (email: string, password: string) => Promise<void>;
+		register: (email: string, password: string) => Promise<void>;
+		logout: () => Promise<void>;
+		refreshTokens: () => Promise<void>;
+		ensureValidToken: () => Promise<void>;
+		init: () => void;
+		clear: () => void;
+	};
+
+	const mockUser = {
+		id: '1',
+		email: 'test@test.com',
+		role: 'user' as const,
+		status: 'active' as const,
+		created_at: '2024-01-01T00:00:00Z',
+		updated_at: '2024-01-01T00:00:00Z'
+	};
+
+	const mockTokenResponse = {
+		access_token: 'access-token-123',
+		refresh_token: 'refresh-token-456',
+		user: mockUser,
+		expires_in: 3600
+	};
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		// Reset localStorage mock
+		const storage: Record<string, string> = {};
+		vi.stubGlobal('localStorage', {
+			getItem: vi.fn((key: string) => storage[key] ?? null),
+			setItem: vi.fn((key: string, value: string) => {
+				storage[key] = value;
+			}),
+			removeItem: vi.fn((key: string) => {
+				delete storage[key];
+			})
+		});
+
+		const { authStore: store } = await import('$lib/stores/auth.svelte');
+		authStore = store as unknown as typeof authStore;
+	});
+
+	afterEach(() => {
+		authStore.clear();
+	});
+
+	describe('login', () => {
+		it('stores tokens and user on successful login', async () => {
+			const { login } = await import('$lib/api/auth');
+			vi.mocked(login).mockResolvedValue(mockTokenResponse);
+
+			await authStore.login('test@test.com', 'password123');
+
+			expect(login).toHaveBeenCalledWith('test@test.com', 'password123');
+			expect(authStore.user).toEqual(mockUser);
+			expect(authStore.accessToken).toBe('access-token-123');
+			expect(authStore.refreshToken).toBe('refresh-token-456');
+			expect(authStore.error).toBeNull();
+		});
+
+		it('stores error on failed login', async () => {
+			const { login } = await import('$lib/api/auth');
+			vi.mocked(login).mockRejectedValue(new Error('Invalid credentials'));
+
+			await expect(
+				authStore.login('test@test.com', 'wrongpassword')
+			).rejects.toThrow('Invalid credentials');
+			expect(authStore.error).toBe('Invalid credentials');
+		});
+	});
+
+	describe('logout', () => {
+		it('clears storage and resets state', async () => {
+			const { logout } = await import('$lib/api/auth');
+			const { goto } = await import('$app/navigation');
+			const { apiClient } = await import('$lib/api/client');
+
+			vi.mocked(logout).mockResolvedValue(undefined);
+
+			// Setup state
+			authStore.user = mockUser;
+			authStore.accessToken = 'token';
+			authStore.refreshToken = 'refresh';
+
+			await authStore.logout();
+
+			expect(logout).toHaveBeenCalledWith('refresh');
+			expect(apiClient.clearStoredTokens).toHaveBeenCalled();
+			expect(authStore.user).toBeNull();
+			expect(authStore.accessToken).toBe('');
+			expect(authStore.refreshToken).toBe('');
+			expect(goto).toHaveBeenCalledWith('/login');
+		});
+	});
+
+	describe('refreshTokens', () => {
+		it('updates tokens on successful refresh', async () => {
+			const { refresh } = await import('$lib/api/auth');
+			const { apiClient } = await import('$lib/api/client');
+
+			const newTokenResponse = {
+				access_token: 'new-access-token',
+				refresh_token: 'new-refresh-token',
+				user: mockUser,
+				expires_in: 7200
+			};
+			vi.mocked(refresh).mockResolvedValue(newTokenResponse);
+
+			authStore.refreshToken = 'old-refresh';
+			await authStore.refreshTokens();
+
+			expect(refresh).toHaveBeenCalledWith('old-refresh');
+			expect(authStore.accessToken).toBe('new-access-token');
+			expect(authStore.refreshToken).toBe('new-refresh-token');
+			expect(apiClient.updateTokens).toHaveBeenCalledWith(
+				'new-access-token',
+				'new-refresh-token',
+				7200
+			);
+		});
+
+		it('clears and redirects on failed refresh', async () => {
+			const { refresh } = await import('$lib/api/auth');
+			const { goto } = await import('$app/navigation');
+
+			vi.mocked(refresh).mockRejectedValue(new Error('Invalid refresh token'));
+
+			authStore.refreshToken = 'bad-token';
+			authStore.user = mockUser;
+
+			await expect(authStore.refreshTokens()).rejects.toThrow('Token refresh failed');
+			expect(authStore.user).toBeNull();
+			expect(goto).toHaveBeenCalledWith('/login');
+		});
+	});
+
+	describe('init', () => {
+		it('restores state from localStorage if tokens valid', async () => {
+			const { me } = await import('$lib/api/auth');
+			const { apiClient } = await import('$lib/api/client');
+
+			const futureExpiry = Date.now() + 60_000;
+			localStorage.setItem('ace_access_token', 'stored-access');
+			localStorage.setItem('ace_refresh_token', 'stored-refresh');
+			localStorage.setItem('ace_expires_at', String(futureExpiry));
+
+			vi.mocked(me).mockResolvedValue(mockUser);
+
+			authStore.init();
+
+			expect(apiClient.setStoredTokens).toHaveBeenCalledWith(
+				'stored-access',
+				'stored-refresh',
+				futureExpiry
+			);
+			expect(authStore.isLoading).toBe(true);
+			// Wait for async me() call
+			await new Promise((r) => setTimeout(r, 10));
+			expect(authStore.user).toEqual(mockUser);
+			expect(authStore.isLoading).toBe(false);
+		});
+
+		it('clears if no tokens in storage', () => {
+			authStore.init();
+
+			expect(authStore.user).toBeNull();
+			expect(authStore.accessToken).toBe('');
+		});
+
+		it('attempts refresh if token expired during init', async () => {
+			const { refresh } = await import('$lib/api/auth');
+			const { apiClient } = await import('$lib/api/client');
+
+			const pastExpiry = Date.now() - 1000;
+			localStorage.setItem('ace_access_token', 'expired-access');
+			localStorage.setItem('ace_refresh_token', 'stored-refresh');
+			localStorage.setItem('ace_expires_at', String(pastExpiry));
+
+			vi.mocked(refresh).mockResolvedValue(mockTokenResponse);
+
+			authStore.init();
+
+			// Wait for the refresh attempt
+			await new Promise((r) => setTimeout(r, 10));
+			expect(refresh).toHaveBeenCalledWith('stored-refresh');
+		});
+	});
+
+	describe('clear', () => {
+		it('resets all state to defaults', async () => {
+			const { apiClient } = await import('$lib/api/client');
+
+			authStore.user = mockUser;
+			authStore.accessToken = 'token';
+			authStore.refreshToken = 'refresh';
+			authStore.expiresAt = Date.now() + 60_000;
+			authStore.error = 'some error';
+
+			authStore.clear();
+
+			expect(authStore.user).toBeNull();
+			expect(authStore.accessToken).toBe('');
+			expect(authStore.refreshToken).toBe('');
+			expect(authStore.expiresAt).toBe(0);
+			expect(authStore.error).toBeNull();
+			expect(apiClient.clearStoredTokens).toHaveBeenCalled();
+			expect(localStorage.getItem('ace_access_token')).toBeNull();
+		});
+	});
+});

--- a/frontend/src/test/stores/notifications.svelte.test.ts
+++ b/frontend/src/test/stores/notifications.svelte.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// We need to test the actual module, so we import it directly
+// But we need to reset the module between tests to avoid state leakage
+
+describe('NotificationStore', () => {
+	let notificationStore: {
+		toasts: unknown[];
+		add: (title: string, variant?: 'success' | 'error' | 'warning' | 'info', description?: string, duration?: number) => string;
+		dismiss: (id: string) => void;
+		success: (title: string, description?: string) => string;
+		error: (title: string, description?: string) => string;
+		warning: (title: string, description?: string) => string;
+		info: (title: string, description?: string) => string;
+	};
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+
+		// Clear module cache to get fresh instance
+		const mod = await import('$lib/stores/notifications.svelte');
+		notificationStore = mod.notificationStore as unknown as typeof notificationStore;
+		// Reset state
+		notificationStore.toasts = [];
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe('add', () => {
+		it('creates toast with correct properties', () => {
+			const id = notificationStore.add('Test Title', 'info', 'Test description', 5000);
+
+			expect(notificationStore.toasts).toHaveLength(1);
+			const toast = notificationStore.toasts[0] as Record<string, unknown>;
+			expect(toast.id).toBe(id);
+			expect(toast.title).toBe('Test Title');
+			expect(toast.variant).toBe('info');
+			expect(toast.description).toBe('Test description');
+			expect(toast.duration).toBe(5000);
+		});
+
+		it('generates unique IDs for each toast', () => {
+			const id1 = notificationStore.add('Toast 1');
+			const id2 = notificationStore.add('Toast 2');
+
+			expect(id1).not.toBe(id2);
+		});
+
+		it('adds toasts to the array', () => {
+			notificationStore.add('First');
+			notificationStore.add('Second');
+			notificationStore.add('Third');
+
+			expect(notificationStore.toasts).toHaveLength(3);
+		});
+	});
+
+	describe('dismiss', () => {
+		it('removes toast by id', () => {
+			const id = notificationStore.add('To dismiss');
+			expect(notificationStore.toasts).toHaveLength(1);
+
+			notificationStore.dismiss(id);
+
+			expect(notificationStore.toasts).toHaveLength(0);
+		});
+
+		it('does nothing for unknown id', () => {
+			notificationStore.add('Test');
+			expect(notificationStore.toasts).toHaveLength(1);
+
+			notificationStore.dismiss('unknown-id');
+
+			expect(notificationStore.toasts).toHaveLength(1);
+		});
+	});
+
+	describe('auto-dismiss', () => {
+		it('auto-dismisses after duration', () => {
+			notificationStore.add('Auto dismiss', 'info', undefined, 5000);
+			expect(notificationStore.toasts).toHaveLength(1);
+
+			vi.advanceTimersByTime(5000);
+
+			expect(notificationStore.toasts).toHaveLength(0);
+		});
+
+		it('does not auto-dismiss when duration is 0', () => {
+			notificationStore.add('Manual dismiss', 'info', undefined, 0);
+			expect(notificationStore.toasts).toHaveLength(1);
+
+			vi.advanceTimersByTime(10000);
+
+			expect(notificationStore.toasts).toHaveLength(1);
+		});
+
+		it('handles multiple toasts with different durations', () => {
+			notificationStore.add('Quick', 'success', undefined, 1000);
+			notificationStore.add('Slow', 'error', undefined, 5000);
+
+			expect(notificationStore.toasts).toHaveLength(2);
+
+			vi.advanceTimersByTime(1000);
+			expect(notificationStore.toasts).toHaveLength(1);
+			expect((notificationStore.toasts[0] as Record<string, unknown>).title).toBe('Slow');
+
+			vi.advanceTimersByTime(4000);
+			expect(notificationStore.toasts).toHaveLength(0);
+		});
+	});
+
+	describe('shorthand methods', () => {
+		it('success creates toast with variant success', () => {
+			const id = notificationStore.success('Success!', 'Operation completed');
+
+			const toast = notificationStore.toasts[0] as Record<string, unknown>;
+			expect(toast.variant).toBe('success');
+			expect(toast.title).toBe('Success!');
+			expect(toast.description).toBe('Operation completed');
+		});
+
+		it('error creates toast with variant error and 8000ms duration', () => {
+			const id = notificationStore.error('Error!', 'Something went wrong');
+
+			const toast = notificationStore.toasts[0] as Record<string, unknown>;
+			expect(toast.variant).toBe('error');
+			expect(toast.title).toBe('Error!');
+			expect(toast.description).toBe('Something went wrong');
+			expect(toast.duration).toBe(8000);
+		});
+
+		it('warning creates toast with variant warning', () => {
+			const id = notificationStore.warning('Warning!', 'Check your input');
+
+			const toast = notificationStore.toasts[0] as Record<string, unknown>;
+			expect(toast.variant).toBe('warning');
+			expect(toast.title).toBe('Warning!');
+		});
+
+		it('info creates toast with variant info', () => {
+			const id = notificationStore.info('Info', 'Here is some information');
+
+			const toast = notificationStore.toasts[0] as Record<string, unknown>;
+			expect(toast.variant).toBe('info');
+			expect(toast.title).toBe('Info');
+		});
+	});
+});


### PR DESCRIPTION
Implements Slice 2: API Client & Auth Store.

## Changes

### API Layer
- types.ts: All TypeScript interfaces (User, TokenResponse, Session, Span, Metric, UsageEvent, etc.)
- client.ts: APIClient with token management, proactive/reactive refresh, error normalization
- auth.ts: Auth API functions (login, register, logout, refresh, me, password reset, magic link)
- sessions.ts: Session API functions (listSessions, revokeSession)

### Stores
- auth.svelte.ts: AuthStore with login/logout/refresh, localStorage persistence, token management
- notifications.svelte.ts: NotificationStore with toast notifications and auto-dismiss

### Tests (39 new tests)
- client.test.ts: Token injection, 401 refresh, refresh mutex, error mapping
- auth.test.ts: API endpoint verification
- auth.svelte.test.ts: Store state management, persistence
- notifications.svelte.test.ts: Toast lifecycle, auto-dismiss

## Test Results
- 87 tests passing (48 existing + 39 new)
- svelte-check: 0 errors
- Build: Success