### PR TITLE
[unit: frontend-design] Slice 3: Validation & Form Utilities

### DIFF
--- a/frontend/src/lib/utils/form.svelte.ts
+++ b/frontend/src/lib/utils/form.svelte.ts
@@ -1,0 +1,126 @@
+import type { ZodSchema, ZodError } from 'zod';
+import type { FieldError } from '$lib/api/types';
+
+interface UseFormOptions<T extends Record<string, unknown>> {
+	initialValues: T;
+	schema: ZodSchema<T>;
+}
+
+interface UseFormReturn<T extends Record<string, unknown>> {
+	values: T;
+	errors: Partial<Record<keyof T, string>>;
+	touched: Partial<Record<keyof T, boolean>>;
+	isSubmitting: boolean;
+	isValid: boolean;
+	isDirty: boolean;
+	validate: () => boolean;
+	validateField: (field: keyof T) => void;
+	reset: () => void;
+	handleSubmit: (onSubmit: (values: T) => Promise<void>) => (e: Event) => Promise<void>;
+	setFieldErrors: (fieldErrors: FieldError[]) => void;
+}
+
+function clearObject<T extends Record<string, unknown>>(obj: T): void {
+	Object.keys(obj).forEach((key) => {
+		delete obj[key as keyof T];
+	});
+}
+
+export function useForm<T extends Record<string, unknown>>(
+	options: UseFormOptions<T>
+): UseFormReturn<T> {
+	const { initialValues, schema } = options;
+
+	const values = $state({ ...initialValues }) as T;
+	const errors = $state({}) as Partial<Record<keyof T, string>>;
+	const touched = $state({}) as Partial<Record<keyof T, boolean>>;
+	const submittingState = $state({ value: false });
+
+	const isValid = $derived(Object.values(errors).every((e) => !e));
+
+	const isDirty = $derived(
+		JSON.stringify(values) !== JSON.stringify(initialValues)
+	);
+
+	function validate(): boolean {
+		const result = schema.safeParse(values);
+		if (result.success) {
+			clearObject(errors);
+			return true;
+		}
+
+		clearObject(errors);
+		const zodError = result.error as ZodError;
+		for (const issue of zodError.issues) {
+			const path = issue.path[0] as keyof T;
+			if (path && !(path in errors)) {
+				errors[path] = issue.message;
+			}
+		}
+		return false;
+	}
+
+	function validateField(field: keyof T): void {
+		touched[field] = true;
+		const result = schema.safeParse(values);
+		if (!result.success) {
+			const zodError = result.error as ZodError;
+			for (const issue of zodError.issues) {
+				if (issue.path[0] === field) {
+					errors[field] = issue.message;
+					return;
+				}
+			}
+		}
+		delete errors[field];
+	}
+
+	function reset(): void {
+		const keys = Object.keys(values) as (keyof T)[];
+		for (const key of keys) {
+			values[key] = initialValues[key];
+		}
+		clearObject(errors);
+		clearObject(touched);
+		submittingState.value = false;
+	}
+
+	function handleSubmit(
+		onSubmit: (values: T) => Promise<void>
+	): (e: Event) => Promise<void> {
+		return function (e: Event) {
+			e.preventDefault();
+			for (const key of Object.keys(values) as (keyof T)[]) {
+				touched[key] = true;
+			}
+			const valid = validate();
+			if (!valid) return Promise.resolve();
+			submittingState.value = true;
+			return onSubmit(values).finally(() => {
+				submittingState.value = false;
+			});
+		};
+	}
+
+	function setFieldErrors(fieldErrors: FieldError[]): void {
+		clearObject(errors);
+		for (const fe of fieldErrors) {
+			errors[fe.field as keyof T] = fe.message;
+		}
+	}
+
+	return {
+		get values() { return values; },
+		get errors() { return errors; },
+		get touched() { return touched; },
+		get isSubmitting() { return submittingState.value; },
+		set isSubmitting(v: boolean) { submittingState.value = v; },
+		get isValid() { return isValid; },
+		get isDirty() { return isDirty; },
+		validate,
+		validateField,
+		reset,
+		handleSubmit,
+		setFieldErrors,
+	};
+}

--- a/frontend/src/lib/utils/formatter.ts
+++ b/frontend/src/lib/utils/formatter.ts
@@ -1,0 +1,175 @@
+import type { UserRole, UserStatus } from '$lib/api/types';
+
+const MONTHS = [
+	'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+	'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+function padZero(n: number): string {
+	return n < 10 ? `0${n}` : `${n}`;
+}
+
+export function formatDate(isoString: string | null | undefined): string {
+	if (!isoString) return '-';
+	const d = new Date(isoString);
+	if (isNaN(d.getTime())) return '-';
+	return `${MONTHS[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
+}
+
+export function formatDateTime(isoString: string | null | undefined): string {
+	if (!isoString) return '-';
+	const d = new Date(isoString);
+	if (isNaN(d.getTime())) return '-';
+	const hours = d.getUTCHours();
+	const minutes = padZero(d.getUTCMinutes());
+	const ampm = hours >= 12 ? 'PM' : 'AM';
+	const displayHours = hours % 12 || 12;
+	return `${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}, ${displayHours}:${minutes} ${ampm}`;
+}
+
+export function formatRelativeTime(isoString: string | null | undefined): string {
+	if (!isoString) return '-';
+	const date = new Date(isoString);
+	if (isNaN(date.getTime())) return '-';
+	const now = Date.now();
+	const diff = now - date.getTime();
+
+	const seconds = Math.floor(diff / 1000);
+	if (seconds < 60) return 'just now';
+
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+
+	const days = Math.floor(hours / 24);
+	if (days < 30) return `${days} day${days === 1 ? '' : 's'} ago`;
+
+	const months = Math.floor(days / 30);
+	if (months < 12) return `${months} month${months === 1 ? '' : 's'} ago`;
+
+	const years = Math.floor(months / 12);
+	return `${years} year${years === 1 ? '' : 's'} ago`;
+}
+
+export function formatDuration(ms: number | null | undefined): string {
+	if (ms === null || ms === undefined) return '-';
+	if (ms <= 0) return '-';
+	if (ms < 1000) return `${ms}ms`;
+
+	const seconds = ms / 1000;
+	if (seconds < 60) {
+		const rounded = Math.round(seconds * 10) / 10;
+		return `${rounded}s`;
+	}
+
+	const minutes = Math.floor(seconds / 60);
+	const remainingSeconds = Math.round(seconds % 60);
+	if (minutes < 60) {
+		if (remainingSeconds === 0) return `${minutes}m`;
+		return `${minutes}m ${remainingSeconds}s`;
+	}
+
+	const hours = Math.floor(minutes / 60);
+	const remainingMinutes = minutes % 60;
+	if (remainingMinutes === 0) return `${hours}h`;
+	return `${hours}h ${remainingMinutes}m`;
+}
+
+export function formatCost(cost: number | null | undefined): string {
+	if (cost === null || cost === undefined) return '-';
+	if (cost < 0) return '-';
+	if (cost === 0) return '$0.00';
+	if (cost < 0.01) {
+		return `$${cost.toFixed(4)}`;
+	}
+	return `$${cost.toFixed(2)}`;
+}
+
+export function formatNumber(n: number | null | undefined): string {
+	if (n === null || n === undefined) return '-';
+	if (n === 0) return '0';
+	if (n < 0) return '-';
+	if (n >= 1_000_000) {
+		return `${(n / 1_000_000).toFixed(1)}M`;
+	}
+	if (n >= 10_000) {
+		return `${(n / 1_000).toFixed(1)}K`;
+	}
+	return n.toLocaleString('en-US');
+}
+
+interface UserAgentInfo {
+	browser: string;
+	os: string;
+	device: string;
+}
+
+export function parseUserAgent(ua: string | null | undefined): UserAgentInfo {
+	if (!ua) {
+		return { browser: 'Unknown', os: 'Unknown', device: 'Unknown' };
+	}
+
+	let browser = 'Unknown';
+	let os = 'Unknown';
+	let device = 'Desktop';
+
+	if (ua.includes('Firefox')) {
+		browser = 'Firefox';
+	} else if (ua.includes('Chrome') && !ua.includes('Edg')) {
+		browser = 'Chrome';
+	} else if (ua.includes('Safari') && !ua.includes('Chrome')) {
+		browser = 'Safari';
+	} else if (ua.includes('Edg')) {
+		browser = 'Edge';
+	} else if (ua.includes('Opera') || ua.includes('OPR')) {
+		browser = 'Opera';
+	}
+
+	if (ua.includes('Windows') || ua.includes('Win64') || ua.includes('Win32')) {
+		os = 'Windows';
+	} else if (ua.includes('iPhone') || ua.includes('iPad') || ua.includes('iOS')) {
+		os = 'iOS';
+		device = 'Mobile';
+	} else if (ua.includes('Android')) {
+		os = 'Android';
+		device = 'Mobile';
+	} else if (ua.includes('Mac OS X') || ua.includes('Macintosh')) {
+		os = 'macOS';
+	} else if (ua.includes('Linux')) {
+		os = 'Linux';
+	}
+
+	if (ua.includes('Mobile') || ua.includes('mobi')) {
+		device = 'Mobile';
+	}
+
+	return { browser, os, device };
+}
+
+export function roleBadgeVariant(role: UserRole): 'default' | 'success' | 'warning' | 'error' {
+	switch (role) {
+		case 'admin':
+			return 'error';
+		case 'user':
+			return 'success';
+		case 'viewer':
+			return 'default';
+		default:
+			return 'default';
+	}
+}
+
+export function statusBadgeVariant(status: UserStatus): 'default' | 'success' | 'warning' | 'error' {
+	switch (status) {
+		case 'active':
+			return 'success';
+		case 'pending':
+			return 'warning';
+		case 'suspended':
+			return 'error';
+		default:
+			return 'default';
+	}
+}

--- a/frontend/src/lib/validation/schemas.ts
+++ b/frontend/src/lib/validation/schemas.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+export const loginSchema = z
+	.object({
+		email: z.string().email('Invalid email format'),
+		password: z.string().min(8, 'Password must be at least 8 characters'),
+	})
+	.refine((data) => data.password.trim().length > 0, {
+		message: 'Password cannot be empty or whitespace only',
+		path: ['password'],
+	});
+
+export const registerSchema = z
+	.object({
+		email: z.string().email('Invalid email format'),
+		password: z.string().min(8, 'Password must be at least 8 characters'),
+		confirmPassword: z.string().min(8, 'Password must be at least 8 characters'),
+	})
+	.refine((data) => data.password === data.confirmPassword, {
+		message: 'Passwords do not match',
+		path: ['confirmPassword'],
+	})
+	.refine((data) => data.password.trim().length > 0, {
+		message: 'Password cannot be empty or whitespace only',
+		path: ['password'],
+	});
+
+export const forgotPasswordSchema = z.object({
+	email: z.string().email('Invalid email format'),
+});
+
+export const resetPasswordSchema = z
+	.object({
+		newPassword: z.string().min(8, 'Password must be at least 8 characters'),
+		confirmPassword: z.string().min(8, 'Password must be at least 8 characters'),
+	})
+	.refine((data) => data.newPassword === data.confirmPassword, {
+		message: 'Passwords do not match',
+		path: ['confirmPassword'],
+	})
+	.refine((data) => data.newPassword.trim().length > 0, {
+		message: 'Password cannot be empty or whitespace only',
+		path: ['newPassword'],
+	});
+
+export const suspendUserSchema = z.object({
+	reason: z.string().max(500, 'Reason must be at most 500 characters').optional(),
+});
+
+export const updateUserRoleSchema = z.object({
+	role: z.enum(['admin', 'user', 'viewer']),
+});
+
+export type LoginInput = z.infer<typeof loginSchema>;
+export type RegisterInput = z.infer<typeof registerSchema>;
+export type ForgotPasswordInput = z.infer<typeof forgotPasswordSchema>;
+export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>;
+export type SuspendUserInput = z.infer<typeof suspendUserSchema>;
+export type UpdateUserRoleInput = z.infer<typeof updateUserRoleSchema>;

--- a/frontend/src/test/utils/form.svelte.test.ts
+++ b/frontend/src/test/utils/form.svelte.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useForm } from '$lib/utils/form.svelte';
+import { loginSchema, registerSchema } from '$lib/validation/schemas';
+import type { FieldError } from '$lib/api/types';
+
+describe('useForm', () => {
+	describe('validate', () => {
+		it('sets errors on invalid input', () => {
+			const form = useForm({
+				initialValues: { email: '', password: '' },
+				schema: loginSchema,
+			});
+
+			const valid = form.validate();
+			expect(valid).toBe(false);
+			expect(form.errors.email).toBe('Invalid email format');
+			expect(form.errors.password).toBe('Password must be at least 8 characters');
+		});
+
+		it('clears errors on valid input', () => {
+			const form = useForm({
+				initialValues: { email: '', password: '' },
+				schema: loginSchema,
+			});
+
+			form.values.email = 'test@example.com';
+			form.values.password = 'password123';
+
+			const valid = form.validate();
+			expect(valid).toBe(true);
+			expect(form.errors.email).toBeUndefined();
+			expect(form.errors.password).toBeUndefined();
+		});
+	});
+
+	describe('validateField', () => {
+		it('validates single field and marks it as touched', () => {
+			const form = useForm({
+				initialValues: { email: '', password: '' },
+				schema: loginSchema,
+			});
+
+			form.validateField('email');
+			expect(form.touched.email).toBe(true);
+			expect(form.errors.email).toBe('Invalid email format');
+		});
+
+		it('clears error when field is valid', () => {
+			const form = useForm({
+				initialValues: { email: '', password: '' },
+				schema: loginSchema,
+			});
+
+			form.errors.email = 'some error';
+			form.values.email = 'test@example.com';
+
+			form.validateField('email');
+			expect(form.errors.email).toBeUndefined();
+		});
+	});
+
+	describe('reset', () => {
+		it('clears all values back to initial', () => {
+			const form = useForm({
+				initialValues: { email: 'original@example.com', password: 'password123' },
+				schema: loginSchema,
+			});
+
+			form.values.email = 'new@example.com';
+			form.values.password = 'newpassword';
+
+			form.reset();
+			expect(form.values.email).toBe('original@example.com');
+			expect(form.values.password).toBe('password123');
+		});
+
+		it('clears errors and touched state', () => {
+			const form = useForm({
+				initialValues: { email: '', password: '' },
+				schema: loginSchema,
+			});
+
+			form.errors.email = 'Invalid email format';
+			form.touched.email = true;
+
+			form.reset();
+			expect(Object.keys(form.errors).length).toBe(0);
+			expect(form.touched.email).toBeUndefined();
+		});
+
+		it('resets isSubmitting to false', () => {
+			const form = useForm({
+				initialValues: { email: '', password: '' },
+				schema: loginSchema,
+			});
+
+			form.isSubmitting = true;
+			form.reset();
+			expect(form.isSubmitting).toBe(false);
+		});
+	});
+
+	describe('handleSubmit', () => {
+		it('calls onSubmit when form is valid', async () => {
+			const form = useForm({
+				initialValues: { email: 'test@example.com', password: 'password123' },
+				schema: loginSchema,
+			});
+
+			const onSubmit = vi.fn().mockResolvedValue(undefined);
+			const handler = form.handleSubmit(onSubmit);
+
+			const event = new Event('submit');
+			await handler(event);
+
+			expect(onSubmit).toHaveBeenCalledWith({
+				email: 'test@example.com',
+				password: 'password123',
+			});
+		});
+
+		it('does not call onSubmit when form is invalid', async () => {
+			const form = useForm({
+				initialValues: { email: '', password: '' },
+				schema: loginSchema,
+			});
+
+			const onSubmit = vi.fn().mockResolvedValue(undefined);
+			const handler = form.handleSubmit(onSubmit);
+
+			const event = new Event('submit');
+			await handler(event);
+
+			expect(onSubmit).not.toHaveBeenCalled();
+		});
+
+		it('marks all fields as touched on submit', async () => {
+			const form = useForm({
+				initialValues: { email: '', password: '' },
+				schema: loginSchema,
+			});
+
+			const onSubmit = vi.fn().mockResolvedValue(undefined);
+			const handler = form.handleSubmit(onSubmit);
+
+			const event = new Event('submit');
+			await handler(event);
+
+			expect(form.touched.email).toBe(true);
+			expect(form.touched.password).toBe(true);
+		});
+
+		it('sets isSubmitting during submission', async () => {
+			const form = useForm({
+				initialValues: { email: 'test@example.com', password: 'password123' },
+				schema: loginSchema,
+			});
+
+			let checkSubmitting = false;
+			const onSubmit = vi.fn().mockImplementation(() => {
+				checkSubmitting = form.isSubmitting;
+				return Promise.resolve();
+			});
+			const handler = form.handleSubmit(onSubmit);
+
+			const event = new Event('submit');
+			await handler(event);
+
+			expect(checkSubmitting).toBe(true);
+			expect(form.isSubmitting).toBe(false);
+		});
+
+		it('resets isSubmitting even if submit throws', async () => {
+			const form = useForm({
+				initialValues: { email: 'test@example.com', password: 'password123' },
+				schema: loginSchema,
+			});
+
+			const onSubmit = vi.fn().mockRejectedValue(new Error('API error'));
+			const handler = form.handleSubmit(onSubmit);
+
+			const event = new Event('submit');
+			await expect(handler(event)).rejects.toThrow('API error');
+
+			expect(form.isSubmitting).toBe(false);
+		});
+	});
+
+	describe('setFieldErrors', () => {
+		it('maps API errors to form fields', () => {
+			const form = useForm({
+				initialValues: { email: '', password: '' },
+				schema: loginSchema,
+			});
+
+			const apiErrors: FieldError[] = [
+				{ field: 'email', message: 'Email already exists' },
+				{ field: 'password', message: 'Password too weak' },
+			];
+
+			form.setFieldErrors(apiErrors);
+			expect(form.errors.email).toBe('Email already exists');
+			expect(form.errors.password).toBe('Password too weak');
+		});
+
+		it('overwrites existing errors', () => {
+			const form = useForm({
+				initialValues: { email: '', password: '' },
+				schema: loginSchema,
+			});
+
+			form.errors.email = 'Old error';
+			const apiErrors: FieldError[] = [
+				{ field: 'email', message: 'New error from API' },
+			];
+
+			form.setFieldErrors(apiErrors);
+			expect(form.errors.email).toBe('New error from API');
+		});
+
+		it('handles empty array', () => {
+			const form = useForm({
+				initialValues: { email: '', password: '' },
+				schema: loginSchema,
+			});
+
+			form.errors.email = 'Some error';
+			form.setFieldErrors([]);
+			expect(form.errors.email).toBeUndefined();
+		});
+	});
+
+	describe('isValid', () => {
+		it('is true when no errors', () => {
+			const form = useForm({
+				initialValues: { email: 'test@example.com', password: 'password123' },
+				schema: loginSchema,
+			});
+
+			expect(form.isValid).toBe(true);
+		});
+
+		it('is false when there are errors', () => {
+			const form = useForm({
+				initialValues: { email: '', password: '' },
+				schema: loginSchema,
+			});
+
+			form.validate();
+			expect(form.isValid).toBe(false);
+		});
+	});
+
+	describe('isDirty', () => {
+		it('is false initially', () => {
+			const form = useForm({
+				initialValues: { email: 'test@example.com', password: 'password123' },
+				schema: loginSchema,
+			});
+
+			expect(form.isDirty).toBe(false);
+		});
+
+		it('is true when value changes', () => {
+			const form = useForm({
+				initialValues: { email: 'test@example.com', password: 'password123' },
+				schema: loginSchema,
+			});
+
+			form.values.email = 'changed@example.com';
+			expect(form.isDirty).toBe(true);
+		});
+
+		it('is false after reset', () => {
+			const form = useForm({
+				initialValues: { email: 'test@example.com', password: 'password123' },
+				schema: loginSchema,
+			});
+
+			form.values.email = 'changed@example.com';
+			form.reset();
+			expect(form.isDirty).toBe(false);
+		});
+	});
+
+	describe('with registerSchema', () => {
+		it('validates password match', () => {
+			const form = useForm({
+				initialValues: {
+					email: 'test@example.com',
+					password: 'password123',
+					confirmPassword: 'different',
+				},
+				schema: registerSchema,
+			});
+
+			const valid = form.validate();
+			expect(valid).toBe(false);
+			expect(form.errors.confirmPassword).toBe('Passwords do not match');
+		});
+
+		it('passes when passwords match', () => {
+			const form = useForm({
+				initialValues: {
+					email: 'test@example.com',
+					password: 'password123',
+					confirmPassword: 'password123',
+				},
+				schema: registerSchema,
+			});
+
+			const valid = form.validate();
+			expect(valid).toBe(true);
+		});
+	});
+});

--- a/frontend/src/test/utils/formatter.test.ts
+++ b/frontend/src/test/utils/formatter.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect } from 'vitest';
+import {
+	formatDate,
+	formatDateTime,
+	formatRelativeTime,
+	formatDuration,
+	formatCost,
+	formatNumber,
+	parseUserAgent,
+	roleBadgeVariant,
+	statusBadgeVariant,
+} from '$lib/utils/formatter';
+import type { UserRole, UserStatus } from '$lib/api/types';
+
+describe('formatDate', () => {
+	it('formats ISO date string correctly', () => {
+		const result = formatDate('2026-01-15T10:30:00Z');
+		expect(result).toBe('Jan 15, 2026');
+	});
+
+	it('formats date with single digit day', () => {
+		const result = formatDate('2026-03-05T00:00:00Z');
+		expect(result).toBe('Mar 5, 2026');
+	});
+
+	it('formats date with single digit month', () => {
+		const result = formatDate('2026-12-25T00:00:00Z');
+		expect(result).toBe('Dec 25, 2026');
+	});
+
+	it('returns dash for null', () => {
+		expect(formatDate(null)).toBe('-');
+	});
+
+	it('returns dash for undefined', () => {
+		expect(formatDate(undefined)).toBe('-');
+	});
+
+	it('returns dash for empty string', () => {
+		expect(formatDate('')).toBe('-');
+	});
+
+	it('returns dash for invalid date', () => {
+		expect(formatDate('not-a-date')).toBe('-');
+	});
+});
+
+describe('formatDateTime', () => {
+	it('formats datetime correctly', () => {
+		const result = formatDateTime('2026-01-15T14:30:00Z');
+		expect(result).toBe('Jan 15, 2026, 2:30 PM');
+	});
+
+	it('formats AM time correctly', () => {
+		const result = formatDateTime('2026-01-15T09:15:00Z');
+		expect(result).toBe('Jan 15, 2026, 9:15 AM');
+	});
+
+	it('formats midnight correctly', () => {
+		const result = formatDateTime('2026-01-15T00:00:00Z');
+		expect(result).toBe('Jan 15, 2026, 12:00 AM');
+	});
+
+	it('returns dash for null', () => {
+		expect(formatDateTime(null)).toBe('-');
+	});
+
+	it('returns dash for undefined', () => {
+		expect(formatDateTime(undefined)).toBe('-');
+	});
+
+	it('returns dash for empty string', () => {
+		expect(formatDateTime('')).toBe('-');
+	});
+
+	it('returns dash for invalid date', () => {
+		expect(formatDateTime('not-a-date')).toBe('-');
+	});
+});
+
+describe('formatRelativeTime', () => {
+	it('returns just now for recent times', () => {
+		const now = new Date();
+		const result = formatRelativeTime(now.toISOString());
+		expect(result).toBe('just now');
+	});
+
+	it('returns minutes ago for times in the past few minutes', () => {
+		const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+		const result = formatRelativeTime(fiveMinutesAgo.toISOString());
+		expect(result).toBe('5 minutes ago');
+	});
+
+	it('returns hours ago for times in the past few hours', () => {
+		const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+		const result = formatRelativeTime(twoHoursAgo.toISOString());
+		expect(result).toBe('2 hours ago');
+	});
+
+	it('returns days ago for times in the past few days', () => {
+		const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
+		const result = formatRelativeTime(threeDaysAgo.toISOString());
+		expect(result).toBe('3 days ago');
+	});
+
+	it('returns dash for null', () => {
+		expect(formatRelativeTime(null)).toBe('-');
+	});
+
+	it('returns dash for undefined', () => {
+		expect(formatRelativeTime(undefined)).toBe('-');
+	});
+
+	it('returns dash for empty string', () => {
+		expect(formatRelativeTime('')).toBe('-');
+	});
+});
+
+describe('formatDuration', () => {
+	it('formats milliseconds', () => {
+		expect(formatDuration(250)).toBe('250ms');
+	});
+
+	it('formats seconds', () => {
+		expect(formatDuration(1500)).toBe('1.5s');
+	});
+
+	it('formats minutes and seconds', () => {
+		expect(formatDuration(65000)).toBe('1m 5s');
+	});
+
+	it('formats just minutes when no remaining seconds', () => {
+		expect(formatDuration(60000)).toBe('1m');
+	});
+
+	it('formats hours and minutes', () => {
+		expect(formatDuration(90 * 60 * 1000)).toBe('1h 30m');
+	});
+
+	it('formats just hours when no remaining minutes', () => {
+		expect(formatDuration(2 * 60 * 60 * 1000)).toBe('2h');
+	});
+
+	it('returns dash for null', () => {
+		expect(formatDuration(null)).toBe('-');
+	});
+
+	it('returns dash for undefined', () => {
+		expect(formatDuration(undefined)).toBe('-');
+	});
+
+	it('returns dash for negative values', () => {
+		expect(formatDuration(-1000)).toBe('-');
+	});
+
+	it('returns dash for zero', () => {
+		expect(formatDuration(0)).toBe('-');
+	});
+});
+
+describe('formatCost', () => {
+	it('formats dollars correctly', () => {
+		expect(formatCost(12.5)).toBe('$12.50');
+	});
+
+	it('formats small costs with more precision', () => {
+		expect(formatCost(0.001234)).toBe('$0.0012');
+	});
+
+	it('formats zero as zero dollars', () => {
+		expect(formatCost(0)).toBe('$0.00');
+	});
+
+	it('formats negative as dash', () => {
+		expect(formatCost(-5)).toBe('-');
+	});
+
+	it('returns dash for null', () => {
+		expect(formatCost(null)).toBe('-');
+	});
+
+	it('returns dash for undefined', () => {
+		expect(formatCost(undefined)).toBe('-');
+	});
+});
+
+describe('formatNumber', () => {
+	it('formats thousands with comma', () => {
+		expect(formatNumber(1234)).toBe('1,234');
+	});
+
+	it('formats millions with M suffix', () => {
+		expect(formatNumber(1500000)).toBe('1.5M');
+	});
+
+	it('formats thousands with K suffix', () => {
+		expect(formatNumber(15000)).toBe('15.0K');
+	});
+
+	it('formats zero', () => {
+		expect(formatNumber(0)).toBe('0');
+	});
+
+	it('returns dash for negative', () => {
+		expect(formatNumber(-100)).toBe('-');
+	});
+
+	it('returns dash for null', () => {
+		expect(formatNumber(null)).toBe('-');
+	});
+
+	it('returns dash for undefined', () => {
+		expect(formatNumber(undefined)).toBe('-');
+	});
+});
+
+describe('parseUserAgent', () => {
+	it('parses Chrome on macOS', () => {
+		const ua =
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+		const result = parseUserAgent(ua);
+		expect(result.browser).toBe('Chrome');
+		expect(result.os).toBe('macOS');
+		expect(result.device).toBe('Desktop');
+	});
+
+	it('parses Safari on macOS', () => {
+		const ua =
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15';
+		const result = parseUserAgent(ua);
+		expect(result.browser).toBe('Safari');
+		expect(result.os).toBe('macOS');
+	});
+
+	it('parses Firefox on Windows', () => {
+		const ua =
+			'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0';
+		const result = parseUserAgent(ua);
+		expect(result.browser).toBe('Firefox');
+		expect(result.os).toBe('Windows');
+	});
+
+	it('parses Edge on Windows', () => {
+		const ua =
+			'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0';
+		const result = parseUserAgent(ua);
+		expect(result.browser).toBe('Edge');
+		expect(result.os).toBe('Windows');
+	});
+
+	it('parses mobile Chrome on Android', () => {
+		const ua =
+			'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36';
+		const result = parseUserAgent(ua);
+		expect(result.browser).toBe('Chrome');
+		expect(result.os).toBe('Android');
+		expect(result.device).toBe('Mobile');
+	});
+
+	it('parses iOS Safari on iPhone', () => {
+		const ua =
+			'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+		const result = parseUserAgent(ua);
+		expect(result.browser).toBe('Safari');
+		expect(result.os).toBe('iOS');
+		expect(result.device).toBe('Mobile');
+	});
+
+	it('returns Unknown for null', () => {
+		const result = parseUserAgent(null);
+		expect(result.browser).toBe('Unknown');
+		expect(result.os).toBe('Unknown');
+		expect(result.device).toBe('Unknown');
+	});
+
+	it('returns Unknown for undefined', () => {
+		const result = parseUserAgent(undefined);
+		expect(result.browser).toBe('Unknown');
+	});
+
+	it('returns Unknown for empty string', () => {
+		const result = parseUserAgent('');
+		expect(result.browser).toBe('Unknown');
+	});
+});
+
+describe('roleBadgeVariant', () => {
+	it('returns error for admin', () => {
+		expect(roleBadgeVariant('admin' as UserRole)).toBe('error');
+	});
+
+	it('returns success for user', () => {
+		expect(roleBadgeVariant('user' as UserRole)).toBe('success');
+	});
+
+	it('returns default for viewer', () => {
+		expect(roleBadgeVariant('viewer' as UserRole)).toBe('default');
+	});
+});
+
+describe('statusBadgeVariant', () => {
+	it('returns success for active', () => {
+		expect(statusBadgeVariant('active' as UserStatus)).toBe('success');
+	});
+
+	it('returns warning for pending', () => {
+		expect(statusBadgeVariant('pending' as UserStatus)).toBe('warning');
+	});
+
+	it('returns error for suspended', () => {
+		expect(statusBadgeVariant('suspended' as UserStatus)).toBe('error');
+	});
+
+	it('returns default for unknown status', () => {
+		expect(statusBadgeVariant('unknown' as UserStatus)).toBe('default');
+	});
+});

--- a/frontend/src/test/validation/schemas.test.ts
+++ b/frontend/src/test/validation/schemas.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest';
+import {
+	loginSchema,
+	registerSchema,
+	forgotPasswordSchema,
+	resetPasswordSchema,
+	suspendUserSchema,
+	updateUserRoleSchema,
+} from '$lib/validation/schemas';
+
+describe('loginSchema', () => {
+	it('passes with valid email and password', () => {
+		const result = loginSchema.safeParse({
+			email: 'test@example.com',
+			password: 'password123',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('fails with invalid email format', () => {
+		const result = loginSchema.safeParse({
+			email: 'notanemail',
+			password: 'password123',
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0].message).toBe('Invalid email format');
+		}
+	});
+
+	it('fails with short password', () => {
+		const result = loginSchema.safeParse({
+			email: 'test@example.com',
+			password: 'short',
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0].message).toBe(
+				'Password must be at least 8 characters'
+			);
+		}
+	});
+
+	it('fails with empty email', () => {
+		const result = loginSchema.safeParse({
+			email: '',
+			password: 'password123',
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('fails with empty password', () => {
+		const result = loginSchema.safeParse({
+			email: 'test@example.com',
+			password: '',
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('fails with whitespace-only password', () => {
+		const result = loginSchema.safeParse({
+			email: 'test@example.com',
+			password: '        ',
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('registerSchema', () => {
+	it('passes with valid inputs', () => {
+		const result = registerSchema.safeParse({
+			email: 'test@example.com',
+			password: 'password123',
+			confirmPassword: 'password123',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('fails when passwords do not match', () => {
+		const result = registerSchema.safeParse({
+			email: 'test@example.com',
+			password: 'password123',
+			confirmPassword: 'different',
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0].message).toBe('Passwords do not match');
+			expect(result.error.issues[0].path).toContain('confirmPassword');
+		}
+	});
+
+	it('fails with invalid email', () => {
+		const result = registerSchema.safeParse({
+			email: 'notanemail',
+			password: 'password123',
+			confirmPassword: 'password123',
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('fails with short password', () => {
+		const result = registerSchema.safeParse({
+			email: 'test@example.com',
+			password: 'short',
+			confirmPassword: 'short',
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('fails with short confirm password', () => {
+		const result = registerSchema.safeParse({
+			email: 'test@example.com',
+			password: 'password123',
+			confirmPassword: 'pass',
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('fails with empty confirm password', () => {
+		const result = registerSchema.safeParse({
+			email: 'test@example.com',
+			password: 'password123',
+			confirmPassword: '',
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('forgotPasswordSchema', () => {
+	it('passes with valid email', () => {
+		const result = forgotPasswordSchema.safeParse({
+			email: 'test@example.com',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('fails with invalid email', () => {
+		const result = forgotPasswordSchema.safeParse({
+			email: 'notanemail',
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('fails with empty email', () => {
+		const result = forgotPasswordSchema.safeParse({
+			email: '',
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('resetPasswordSchema', () => {
+	it('passes with valid inputs', () => {
+		const result = resetPasswordSchema.safeParse({
+			newPassword: 'password123',
+			confirmPassword: 'password123',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('fails when passwords do not match', () => {
+		const result = resetPasswordSchema.safeParse({
+			newPassword: 'password123',
+			confirmPassword: 'different',
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0].message).toBe('Passwords do not match');
+		}
+	});
+
+	it('fails with short new password', () => {
+		const result = resetPasswordSchema.safeParse({
+			newPassword: 'short',
+			confirmPassword: 'short',
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('suspendUserSchema', () => {
+	it('passes with no reason', () => {
+		const result = suspendUserSchema.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	it('passes with optional reason', () => {
+		const result = suspendUserSchema.safeParse({
+			reason: 'Violation of terms',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('passes with empty reason', () => {
+		const result = suspendUserSchema.safeParse({
+			reason: '',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('fails with reason exceeding 500 characters', () => {
+		const result = suspendUserSchema.safeParse({
+			reason: 'a'.repeat(501),
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0].message).toBe(
+				'Reason must be at most 500 characters'
+			);
+		}
+	});
+
+	it('passes with exactly 500 characters', () => {
+		const result = suspendUserSchema.safeParse({
+			reason: 'a'.repeat(500),
+		});
+		expect(result.success).toBe(true);
+	});
+});
+
+describe('updateUserRoleSchema', () => {
+	it('passes with admin role', () => {
+		const result = updateUserRoleSchema.safeParse({ role: 'admin' });
+		expect(result.success).toBe(true);
+	});
+
+	it('passes with user role', () => {
+		const result = updateUserRoleSchema.safeParse({ role: 'user' });
+		expect(result.success).toBe(true);
+	});
+
+	it('passes with viewer role', () => {
+		const result = updateUserRoleSchema.safeParse({ role: 'viewer' });
+		expect(result.success).toBe(true);
+	});
+
+	it('fails with invalid role', () => {
+		const result = updateUserRoleSchema.safeParse({ role: 'superadmin' });
+		expect(result.success).toBe(false);
+	});
+
+	it('fails with empty role', () => {
+		const result = updateUserRoleSchema.safeParse({ role: '' });
+		expect(result.success).toBe(false);
+	});
+});


### PR DESCRIPTION
Implements Slice 3: Validation & Form Utilities.

## Changes

### Validation Layer
- schemas.ts: Zod schemas for login, register, forgot/reset password, suspend user, update role
- Full validation with custom error messages and refinements

### Form Utilities
- form.svelte.ts: useForm composable with Svelte 5 runes
  - Reactive state: values, errors, touched, isSubmitting
  - Derived state: isValid, isDirty
  - Methods: validate, validateField, reset, handleSubmit, setFieldErrors

### Formatters
- formatter.ts: 9 formatting utilities
  - Date/time: formatDate, formatDateTime, formatRelativeTime
  - Duration & cost: formatDuration, formatCost
  - Numbers: formatNumber (with K/M suffixes)
  - User agent parsing
  - Badge variant mapping for roles/status

### Tests (110 new tests)
- schemas.test.ts: 28 validation tests
- formatter.test.ts: 60 formatter tests
- form.svelte.test.ts: 22 useForm tests

## Test Results
- 197 tests passing (87 existing + 110 new)
- svelte-check: 0 errors
- Build: Success