### PR TITLE
[unit: realtime-ui] Slice 1: Message Types & SeqBuffer

### DIFF
--- a/backend/internal/api/realtime/message.go
+++ b/backend/internal/api/realtime/message.go
@@ -1,0 +1,184 @@
+package realtime
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// Topic format: agent:{id}:status, agent:{id}:logs, agent:{id}:cycles, system:health, usage:{id}
+// Format: resourceType(:resourceId(:subType)?)?
+var (
+	TopicRegex = regexp.MustCompile(`^[a-z][a-z0-9]*(:[a-z0-9_-]+(:[a-z_][a-z0-9_]*)?)?$`)
+)
+
+// ValidateTopic checks if a topic string matches the expected format.
+func ValidateTopic(topic string) error {
+	if !TopicRegex.MatchString(topic) {
+		return fmt.Errorf("invalid topic format: %q", topic)
+	}
+	return nil
+}
+
+// ClientMessageType represents the type of a client message.
+type ClientMessageType string
+
+const (
+	ClientMessageAuth        ClientMessageType = "auth"
+	ClientMessageSubscribe   ClientMessageType = "subscribe"
+	ClientMessageUnsubscribe ClientMessageType = "unsubscribe"
+	ClientMessageReplay      ClientMessageType = "replay"
+	ClientMessagePing        ClientMessageType = "ping"
+)
+
+// ServerMessageType represents the type of a server message.
+type ServerMessageType string
+
+const (
+	ServerMessageAuthOk         ServerMessageType = "auth_ok"
+	ServerMessageAuthError      ServerMessageType = "auth_error"
+	ServerMessageSubscribed     ServerMessageType = "subscribed"
+	ServerMessageUnsubscribed   ServerMessageType = "unsubscribed"
+	ServerMessageEvent          ServerMessageType = "event"
+	ServerMessageResyncRequired ServerMessageType = "resync_required"
+	ServerMessagePong           ServerMessageType = "pong"
+	ServerMessageError          ServerMessageType = "error"
+)
+
+// BaseMessage contains common fields for all messages.
+type BaseMessage struct {
+	Type  string `json:"type"`
+	Topic string `json:"topic,omitempty"`
+	Seq   uint64 `json:"seq,omitempty"`
+}
+
+// ClientMessage represents a message sent from the client to the server.
+type ClientMessage struct {
+	Type      ClientMessageType `json:"type"`
+	Topic     string            `json:"topic,omitempty"`
+	Topics    []string          `json:"topics,omitempty"`
+	Seq       uint64            `json:"seq,omitempty"`
+	Data      json.RawMessage   `json:"data,omitempty"`
+	Token     string            `json:"token,omitempty"`
+	SinceSeq  uint64            `json:"since_seq,omitempty"`
+	SinceTime int64             `json:"since_time,omitempty"`
+}
+
+// AuthClientMessage is the auth message payload.
+type AuthClientMessage struct {
+	Token string `json:"token"`
+}
+
+// MarshalJSON implements json.Marshaler for ClientMessage.
+func (c ClientMessage) MarshalJSON() ([]byte, error) {
+	if c.Type == "" {
+		c.Type = ClientMessagePing
+	}
+	type alias ClientMessage
+	return json.Marshal(alias(c))
+}
+
+// ServerMessage represents a message sent from the server to the client.
+type ServerMessage struct {
+	Type         ServerMessageType `json:"type"`
+	Topic        string            `json:"topic,omitempty"`
+	Topics       []string          `json:"topics,omitempty"`
+	Seq          uint64            `json:"seq,omitempty"`
+	Data         json.RawMessage   `json:"data,omitempty"`
+	Error        string            `json:"error,omitempty"`
+	ConnectionID string            `json:"connection_id,omitempty"`
+	Resync       []string          `json:"resync_required,omitempty"`
+}
+
+// EventData represents the data payload of an event message.
+type EventData struct {
+	EventType string          `json:"event_type"`
+	Data      json.RawMessage `json:"data"`
+}
+
+// Marshal implements json.Marshaler for EventData.
+func (e EventData) Marshal() json.RawMessage {
+	data, _ := json.Marshal(e)
+	return data
+}
+
+// NewAuthOkMessage creates an auth_ok server message.
+func NewAuthOkMessage(connectionID string) ServerMessage {
+	return ServerMessage{
+		Type:         ServerMessageAuthOk,
+		ConnectionID: connectionID,
+	}
+}
+
+// NewAuthErrorMessage creates an auth_error server message.
+func NewAuthErrorMessage(err string) ServerMessage {
+	return ServerMessage{
+		Type:  ServerMessageAuthError,
+		Error: err,
+	}
+}
+
+// NewSubscribedMessage creates a subscribed server message.
+func NewSubscribedMessage(topics []string) ServerMessage {
+	return ServerMessage{
+		Type:   ServerMessageSubscribed,
+		Topics: topics,
+	}
+}
+
+// NewUnsubscribedMessage creates an unsubscribed server message.
+func NewUnsubscribedMessage(topics []string) ServerMessage {
+	return ServerMessage{
+		Type:   ServerMessageUnsubscribed,
+		Topics: topics,
+	}
+}
+
+// NewEventMessage creates an event server message.
+func NewEventMessage(topic string, seq uint64, eventType string, data json.RawMessage) ServerMessage {
+	return ServerMessage{
+		Type:  ServerMessageEvent,
+		Topic: topic,
+		Seq:   seq,
+		Data: EventData{
+			EventType: eventType,
+			Data:      data,
+		}.Marshal(),
+	}
+}
+
+// NewResyncRequiredMessage creates a resync_required server message.
+func NewResyncRequiredMessage(topics []string) ServerMessage {
+	return ServerMessage{
+		Type:   ServerMessageResyncRequired,
+		Resync: topics,
+	}
+}
+
+// NewPongMessage creates a pong server message.
+func NewPongMessage() ServerMessage {
+	return ServerMessage{
+		Type: ServerMessagePong,
+	}
+}
+
+// NewErrorMessage creates an error server message.
+func NewErrorMessage(err string) ServerMessage {
+	return ServerMessage{
+		Type:  ServerMessageError,
+		Error: err,
+	}
+}
+
+// Marshal implements json.Marshaler for ServerMessage.
+func (s ServerMessage) Marshal() json.RawMessage {
+	data, _ := json.Marshal(s)
+	return data
+}
+
+// ErrInvalidTopic is returned when a topic format is invalid.
+var ErrInvalidTopic = errors.New("invalid topic format")
+
+// ErrBufferExceeded is returned when the sequence buffer cannot hold more events.
+var ErrBufferExceeded = errors.New("buffer exceeded")

--- a/backend/internal/api/realtime/seq.go
+++ b/backend/internal/api/realtime/seq.go
@@ -1,0 +1,196 @@
+package realtime
+
+import (
+	"sync"
+	"time"
+)
+
+// SeqEntry represents a single entry in the sequence buffer.
+type SeqEntry struct {
+	Seq  uint64
+	Data []byte
+	Time time.Time
+}
+
+// SeqBufferConfig holds configuration for the sequence buffer.
+type SeqBufferConfig struct {
+	MaxSize int           // Maximum entries per topic
+	MaxAge  time.Duration // Maximum age before entry expires
+}
+
+// DefaultSeqBufferConfig returns the default buffer configuration.
+func DefaultSeqBufferConfig() SeqBufferConfig {
+	return SeqBufferConfig{
+		MaxSize: 1000,
+		MaxAge:  10 * time.Minute,
+	}
+}
+
+// SeqBuffer provides per-topic ring buffers for event replay.
+type SeqBuffer struct {
+	mu     sync.RWMutex
+	buf    map[string][]SeqEntry
+	config SeqBufferConfig
+}
+
+// NewSeqBuffer creates a new sequence buffer with the given configuration.
+func NewSeqBuffer(config SeqBufferConfig) *SeqBuffer {
+	if config.MaxSize <= 0 {
+		config = DefaultSeqBufferConfig()
+	}
+	return &SeqBuffer{
+		buf:    make(map[string][]SeqEntry),
+		config: config,
+	}
+}
+
+// Append adds an entry to the topic's ring buffer.
+func (s *SeqBuffer) Append(topic string, seq uint64, data []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry := SeqEntry{
+		Seq:  seq,
+		Data: data,
+		Time: time.Now(),
+	}
+
+	// Get or create the topic buffer
+	buffer := s.buf[topic]
+	if buffer == nil {
+		buffer = make([]SeqEntry, 0, s.config.MaxSize)
+	}
+
+	// Append to ring buffer
+	buffer = append(buffer, entry)
+
+	// Enforce max size (ring buffer behavior)
+	if len(buffer) > s.config.MaxSize {
+		// Remove oldest entries
+		excess := len(buffer) - s.config.MaxSize
+		buffer = buffer[excess:]
+	}
+
+	s.buf[topic] = buffer
+}
+
+// Replay returns events from the topic buffer since the given sequence number.
+// Returns ErrBufferExceeded if the requested sequence is too old.
+func (s *SeqBuffer) Replay(topic string, sinceSeq uint64) ([]SeqEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	buffer, ok := s.buf[topic]
+	if !ok {
+		return nil, nil
+	}
+
+	// Find starting position
+	startIdx := -1
+	for i, entry := range buffer {
+		if entry.Seq > sinceSeq {
+			startIdx = i
+			break
+		}
+	}
+
+	// Check for gap: if buffer is full and sinceSeq is in the range of lost entries
+	// We lost entries [1, buffer[0].Seq-1] due to compaction
+	// sinceSeq=0 means "replay all" (special case, no error)
+	// sinceSeq >= buffer[0].Seq means the entry at sinceSeq is available
+	// sinceSeq in (0, buffer[0].Seq) means we lost entries and can't replay
+	if s.config.MaxSize > 0 && len(buffer) >= s.config.MaxSize && sinceSeq > 0 && sinceSeq < buffer[0].Seq {
+		return nil, ErrBufferExceeded
+	}
+
+	if startIdx == -1 {
+		return nil, nil
+	}
+
+	// Filter expired entries
+	var result []SeqEntry
+	for i := startIdx; i < len(buffer); i++ {
+		entry := buffer[i]
+		if s.config.MaxAge > 0 && time.Since(entry.Time) > s.config.MaxAge {
+			continue
+		}
+		result = append(result, entry)
+	}
+
+	return result, nil
+}
+
+// GetLastSeq returns the last sequence number for a topic, or 0 if no events.
+func (s *SeqBuffer) GetLastSeq(topic string) uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	buffer, ok := s.buf[topic]
+	if !ok || len(buffer) == 0 {
+		return 0
+	}
+	return buffer[len(buffer)-1].Seq
+}
+
+// Size returns the number of entries in the buffer for a topic.
+func (s *SeqBuffer) Size(topic string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	buffer, ok := s.buf[topic]
+	if !ok {
+		return 0
+	}
+	return len(buffer)
+}
+
+// RemoveTopic removes all entries for a topic.
+func (s *SeqBuffer) RemoveTopic(topic string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.buf, topic)
+}
+
+// CleanExpired removes expired entries from all topic buffers.
+func (s *SeqBuffer) CleanExpired() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.config.MaxAge <= 0 {
+		return 0
+	}
+
+	now := time.Now()
+	removed := 0
+
+	for topic, buffer := range s.buf {
+		var newBuffer []SeqEntry
+		for _, entry := range buffer {
+			if now.Sub(entry.Time) <= s.config.MaxAge {
+				newBuffer = append(newBuffer, entry)
+			} else {
+				removed++
+			}
+		}
+		if len(newBuffer) == 0 {
+			delete(s.buf, topic)
+		} else {
+			s.buf[topic] = newBuffer
+		}
+	}
+
+	return removed
+}
+
+// Topics returns all topics currently in the buffer.
+func (s *SeqBuffer) Topics() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	topics := make([]string, 0, len(s.buf))
+	for topic := range s.buf {
+		topics = append(topics, topic)
+	}
+	return topics
+}

--- a/backend/internal/api/realtime/seq_test.go
+++ b/backend/internal/api/realtime/seq_test.go
@@ -1,0 +1,341 @@
+package realtime
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeqBuffer_Append(t *testing.T) {
+	buf := NewSeqBuffer(SeqBufferConfig{MaxSize: 10, MaxAge: time.Minute})
+
+	// Append events to a topic
+	for i := uint64(1); i <= 5; i++ {
+		data, _ := json.Marshal(map[string]int{"seq": int(i)})
+		buf.Append("agent:1:status", i, data)
+	}
+
+	assert.Equal(t, 5, buf.Size("agent:1:status"))
+	assert.Equal(t, uint64(5), buf.GetLastSeq("agent:1:status"))
+}
+
+func TestSeqBuffer_AppendRingBuffer(t *testing.T) {
+	buf := NewSeqBuffer(SeqBufferConfig{MaxSize: 5, MaxAge: time.Minute})
+
+	// Append more events than max size
+	for i := uint64(1); i <= 10; i++ {
+		data, _ := json.Marshal(map[string]int{"seq": int(i)})
+		buf.Append("agent:1:status", i, data)
+	}
+
+	// Should only have last 5 events
+	assert.Equal(t, 5, buf.Size("agent:1:status"))
+	assert.Equal(t, uint64(10), buf.GetLastSeq("agent:1:status"))
+
+	// Replay should start from seq 6
+	entries, err := buf.Replay("agent:1:status", 0)
+	require.NoError(t, err)
+	assert.Len(t, entries, 5)
+	assert.Equal(t, uint64(6), entries[0].Seq)
+}
+
+func TestSeqBuffer_ReplayWithinBuffer(t *testing.T) {
+	buf := NewSeqBuffer(SeqBufferConfig{MaxSize: 10, MaxAge: time.Minute})
+
+	// Append events
+	for i := uint64(1); i <= 5; i++ {
+		data, _ := json.Marshal(map[string]int{"seq": int(i)})
+		buf.Append("agent:1:status", i, data)
+	}
+
+	// Replay since seq 3
+	entries, err := buf.Replay("agent:1:status", 3)
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, uint64(4), entries[0].Seq)
+	assert.Equal(t, uint64(5), entries[1].Seq)
+}
+
+func TestSeqBuffer_ReplayBeyondBuffer(t *testing.T) {
+	buf := NewSeqBuffer(SeqBufferConfig{MaxSize: 5, MaxAge: time.Minute})
+
+	// Append 10 events (but buffer only holds 5)
+	for i := uint64(1); i <= 10; i++ {
+		data, _ := json.Marshal(map[string]int{"seq": int(i)})
+		buf.Append("agent:1:status", i, data)
+	}
+
+	// Replay since seq 3 (should fail - buffer only holds 6-10)
+	_, err := buf.Replay("agent:1:status", 3)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrBufferExceeded)
+}
+
+func TestSeqBuffer_ReplayNonExistentTopic(t *testing.T) {
+	buf := NewSeqBuffer(SeqBufferConfig{MaxSize: 10, MaxAge: time.Minute})
+
+	entries, err := buf.Replay("nonexistent", 0)
+	require.NoError(t, err)
+	assert.Nil(t, entries)
+}
+
+func TestSeqBuffer_Expiry(t *testing.T) {
+	buf := NewSeqBuffer(SeqBufferConfig{MaxSize: 10, MaxAge: 50 * time.Millisecond})
+
+	// Append an event
+	data, _ := json.Marshal(map[string]int{"seq": 1})
+	buf.Append("agent:1:status", 1, data)
+	assert.Equal(t, 1, buf.Size("agent:1:status"))
+
+	// Wait for expiry
+	time.Sleep(100 * time.Millisecond)
+
+	// Clean expired entries
+	removed := buf.CleanExpired()
+	assert.Equal(t, 1, removed)
+	assert.Equal(t, 0, buf.Size("agent:1:status"))
+}
+
+func TestSeqBuffer_ConcurrentAccess(t *testing.T) {
+	buf := NewSeqBuffer(SeqBufferConfig{MaxSize: 100, MaxAge: time.Minute})
+	var wg sync.WaitGroup
+
+	// Concurrent appends
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := uint64(0); j < 100; j++ {
+				data, _ := json.Marshal(map[string]int{"id": id, "seq": int(j)})
+				buf.Append("agent:1:status", j, data)
+			}
+		}(i)
+	}
+
+	// Concurrent replays
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				_, _ = buf.Replay("agent:1:status", uint64(j))
+				_ = buf.Size("agent:1:status")
+				_ = buf.GetLastSeq("agent:1:status")
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Should have some events in buffer
+	assert.GreaterOrEqual(t, buf.Size("agent:1:status"), 0)
+}
+
+func TestSeqBuffer_MultipleTopics(t *testing.T) {
+	buf := NewSeqBuffer(SeqBufferConfig{MaxSize: 5, MaxAge: time.Minute})
+
+	// Append to multiple topics
+	buf.Append("agent:1:status", 1, []byte(`{"seq":1}`))
+	buf.Append("agent:1:status", 2, []byte(`{"seq":2}`))
+	buf.Append("agent:2:status", 1, []byte(`{"seq":1}`))
+	buf.Append("system:health", 1, []byte(`{"seq":1}`))
+
+	assert.Equal(t, 2, buf.Size("agent:1:status"))
+	assert.Equal(t, 1, buf.Size("agent:2:status"))
+	assert.Equal(t, 1, buf.Size("system:health"))
+
+	topics := buf.Topics()
+	assert.Len(t, topics, 3)
+}
+
+func TestSeqBuffer_RemoveTopic(t *testing.T) {
+	buf := NewSeqBuffer(SeqBufferConfig{MaxSize: 5, MaxAge: time.Minute})
+
+	buf.Append("agent:1:status", 1, []byte(`{"seq":1}`))
+	buf.Append("agent:1:status", 2, []byte(`{"seq":2}`))
+	assert.Equal(t, 2, buf.Size("agent:1:status"))
+
+	buf.RemoveTopic("agent:1:status")
+	assert.Equal(t, 0, buf.Size("agent:1:status"))
+	assert.Equal(t, uint64(0), buf.GetLastSeq("agent:1:status"))
+}
+
+func TestMessageTypes_ClientMessageJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		msg      ClientMessage
+		wantType ClientMessageType
+	}{
+		{
+			name: "auth message",
+			msg: ClientMessage{
+				Type:  ClientMessageAuth,
+				Token: "jwt-token",
+			},
+			wantType: ClientMessageAuth,
+		},
+		{
+			name: "subscribe message",
+			msg: ClientMessage{
+				Type:   ClientMessageSubscribe,
+				Topics: []string{"agent:1:status", "system:health"},
+			},
+			wantType: ClientMessageSubscribe,
+		},
+		{
+			name: "unsubscribe message",
+			msg: ClientMessage{
+				Type:   ClientMessageUnsubscribe,
+				Topics: []string{"agent:1:status"},
+			},
+			wantType: ClientMessageUnsubscribe,
+		},
+		{
+			name: "replay message",
+			msg: ClientMessage{
+				Type:     ClientMessageReplay,
+				Topic:    "agent:1:status",
+				SinceSeq: 100,
+			},
+			wantType: ClientMessageReplay,
+		},
+		{
+			name:     "ping message",
+			msg:      ClientMessage{Type: ClientMessagePing},
+			wantType: ClientMessagePing,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.msg)
+			require.NoError(t, err)
+
+			var decoded ClientMessage
+			err = json.Unmarshal(data, &decoded)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantType, decoded.Type)
+		})
+	}
+}
+
+func TestMessageTypes_ServerMessageJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		msg      ServerMessage
+		wantType ServerMessageType
+	}{
+		{
+			name:     "auth_ok message",
+			msg:      NewAuthOkMessage("conn-123"),
+			wantType: ServerMessageAuthOk,
+		},
+		{
+			name:     "auth_error message",
+			msg:      NewAuthErrorMessage("invalid token"),
+			wantType: ServerMessageAuthError,
+		},
+		{
+			name:     "subscribed message",
+			msg:      NewSubscribedMessage([]string{"agent:1:status"}),
+			wantType: ServerMessageSubscribed,
+		},
+		{
+			name:     "unsubscribed message",
+			msg:      NewUnsubscribedMessage([]string{"agent:1:status"}),
+			wantType: ServerMessageUnsubscribed,
+		},
+		{
+			name: "event message",
+			msg: NewEventMessage(
+				"agent:1:status",
+				42,
+				"agent.status_change",
+				json.RawMessage(`{"status":"running"}`),
+			),
+			wantType: ServerMessageEvent,
+		},
+		{
+			name:     "resync_required message",
+			msg:      NewResyncRequiredMessage([]string{"agent:1:status"}),
+			wantType: ServerMessageResyncRequired,
+		},
+		{
+			name:     "pong message",
+			msg:      NewPongMessage(),
+			wantType: ServerMessagePong,
+		},
+		{
+			name:     "error message",
+			msg:      NewErrorMessage("something went wrong"),
+			wantType: ServerMessageError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.msg)
+			require.NoError(t, err)
+
+			var decoded ServerMessage
+			err = json.Unmarshal(data, &decoded)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantType, decoded.Type)
+		})
+	}
+}
+
+func TestValidateTopic(t *testing.T) {
+	tests := []struct {
+		topic string
+		valid bool
+	}{
+		{"agent:1:status", true},
+		{"agent:abc-123:logs", true},
+		{"agent:123:cycles", true},
+		{"system:health", true},
+		{"usage:user-123", true},
+		{"usage:user_456", true},
+		{"Agent:1:status", false},       // uppercase
+		{"agent:1:Status", false},       // uppercase
+		{"agent::status", false},        // empty segment
+		{"agent:1:", false},             // empty segment
+		{":1:status", false},            // empty segment
+		{"agent-1:status", false},       // dash in first segment
+		{"agent:1:status:extra", false}, // too many segments
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.topic, func(t *testing.T) {
+			err := ValidateTopic(tt.topic)
+			if tt.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestSeqBuffer_ReplaySinceTime(t *testing.T) {
+	buf := NewSeqBuffer(SeqBufferConfig{MaxSize: 10, MaxAge: time.Hour})
+
+	topic := "agent:1:status"
+
+	// Append events with different timestamps (simulated)
+	for i := uint64(1); i <= 5; i++ {
+		data, _ := json.Marshal(map[string]int{"seq": int(i)})
+		buf.Append(topic, i, data)
+	}
+
+	// Replay should work normally
+	entries, err := buf.Replay(topic, 2)
+	require.NoError(t, err)
+	assert.Len(t, entries, 3)
+}


### PR DESCRIPTION
## Summary
Implements Slice 1 of the real-time UI unit: Message Types and Sequence Buffer foundation.

## Changes

### Backend
- `internal/api/realtime/message.go` — Discriminated union message types
  - ClientMessage: `auth`, `subscribe`, `unsubscribe`, `replay`, `ping`
  - ServerMessage: `auth_ok`, `auth_error`, `subscribed`, `unsubscribed`, `event`, `resync_required`, `pong`, `error`
  - Topic validation regex for `agent:{id}:status`, `system:health`, etc.
  
- `internal/api/realtime/seq.go` — SeqBuffer with per-topic ring buffers
  - `Append()`, `Replay()`, `GetLastSeq()`, `Size()`, `RemoveTopic()`
  - Thread-safe with `sync.RWMutex`
  - Returns `ErrBufferExceeded` for gaps

- `internal/api/realtime/seq_test.go` — Comprehensive tests
  - SeqBuffer: append, overflow, replay, concurrent access, expiry
  - Message types: JSON round-trip tests
  - Topic validation tests

## Test Results
```
ok  ace/internal/api/realtime  0.104s
```

## Validation
Run `go test ./internal/api/realtime/...` to verify.

## Related
- Implements Slice 1 from implementation_plan.md
- Foundation for Slice 2 (TopicReg)