### PR TITLE
[unit: realtime-ui] Slice 4: WebSocket handler, polling endpoint, router & app wiring

### DIFF
--- a/backend/internal/api/realtime/handler.go
+++ b/backend/internal/api/realtime/handler.go
@@ -1,0 +1,126 @@
+package realtime
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	mw "ace/internal/api/middleware"
+	"ace/internal/api/model"
+	"ace/internal/api/service"
+)
+
+const wsAuthTimeout = 5 * time.Second
+
+// HandleWebSocket upgrades the connection, performs auth handshake, then drives the client pumps.
+// No HTTP auth middleware — auth is via the first WebSocket message.
+func HandleWebSocket(hub *Hub, tokenService *service.TokenService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			CompressionMode: websocket.CompressionDisabled,
+		})
+		if err != nil {
+			hub.logger.Warn("websocket accept failed", zap.Error(err))
+			return
+		}
+
+		authCtx, cancel := context.WithTimeout(r.Context(), wsAuthTimeout)
+		defer cancel()
+
+		var authMsg ClientMessage
+		if err := wsjson.Read(authCtx, conn, &authMsg); err != nil {
+			conn.Close(websocket.StatusPolicyViolation, "auth timeout")
+			hub.logger.Warn("ws auth read failed", zap.Error(err))
+			return
+		}
+
+		if authMsg.Type != ClientMessageAuth || authMsg.Token == "" {
+			conn.Close(websocket.StatusPolicyViolation, "first message must be auth")
+			return
+		}
+
+		claims, err := tokenService.ValidateAccessToken(authMsg.Token)
+		if err != nil {
+			conn.Close(websocket.StatusPolicyViolation, "invalid token")
+			hub.logger.Warn("ws auth token invalid", zap.Error(err))
+			return
+		}
+
+		c := NewClient(conn, claims.Sub.String(), model.UserRole(claims.Role), hub)
+		hub.Register(c)
+
+		connCtx := r.Context()
+		go c.writePump(connCtx)
+		c.readPump(connCtx)
+	}
+}
+
+// pollingResponse is the JSON payload for GET /api/realtime/updates.
+type pollingResponse struct {
+	Events         []pollingEvent `json:"events"`
+	CurrentSeq     uint64         `json:"current_seq"`
+	HasMore        bool           `json:"has_more"`
+	ResyncRequired []string       `json:"resync_required,omitempty"`
+}
+
+type pollingEvent struct {
+	Topic string          `json:"topic"`
+	Seq   uint64          `json:"seq"`
+	Data  json.RawMessage `json:"data"`
+}
+
+// HandlePolling serves buffered events for authenticated users via HTTP GET.
+// Relies on the existing auth middleware setting userID and role in context.
+func HandlePolling(hub *Hub) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		rawID := mw.GetUserIDFromContext(r.Context())
+		var userID string
+		switch v := rawID.(type) {
+		case uuid.UUID:
+			userID = v.String()
+		case string:
+			userID = v
+		}
+		role := mw.GetUserRoleFromContext(r.Context())
+
+		var topics []string
+		if raw := r.URL.Query().Get("topics"); raw != "" {
+			topics = strings.Split(raw, ",")
+		}
+
+		var sinceSeq uint64
+		if raw := r.URL.Query().Get("since_seq"); raw != "" {
+			if v, err := strconv.ParseUint(raw, 10, 64); err == nil {
+				sinceSeq = v
+			}
+		}
+
+		result := hub.PollEvents(userID, role, topics, sinceSeq)
+
+		resp := pollingResponse{
+			Events:         make([]pollingEvent, 0, len(result.Events)),
+			ResyncRequired: result.ResyncRequired,
+		}
+		for _, e := range result.Events {
+			resp.Events = append(resp.Events, pollingEvent{
+				Topic: e.Topic,
+				Seq:   e.Seq,
+				Data:  e.Data,
+			})
+			if e.Seq > resp.CurrentSeq {
+				resp.CurrentSeq = e.Seq
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}
+}

--- a/backend/internal/api/realtime/handler_test.go
+++ b/backend/internal/api/realtime/handler_test.go
@@ -1,0 +1,321 @@
+package realtime
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+	"go.uber.org/zap"
+
+	"ace/internal/api/middleware"
+	"ace/internal/api/model"
+	"ace/internal/api/service"
+)
+
+func newTestTokenService(t *testing.T) *service.TokenService {
+	t.Helper()
+	svc, err := service.NewTokenService(&service.TokenConfig{
+		Issuer:         "test",
+		Audience:       "test",
+		AccessTokenTTL: 15 * time.Minute,
+	})
+	require.NoError(t, err)
+	return svc
+}
+
+func mintToken(t *testing.T, svc *service.TokenService, userID uuid.UUID, role model.UserRole) string {
+	t.Helper()
+	token, err := svc.GenerateAccessToken(&model.TokenClaims{
+		Sub:  userID,
+		Role: string(role),
+		Iss:  "test",
+		Aud:  "test",
+	})
+	require.NoError(t, err)
+	return token
+}
+
+func newHandlerHub(t *testing.T) *Hub {
+	t.Helper()
+	logger, _ := zap.NewDevelopment()
+	meter := noop.NewMeterProvider().Meter("test")
+	return NewHub(testNATSConn, logger, meter)
+}
+
+// serveWS starts an httptest server running HandleWebSocket and returns its URL.
+func serveWS(t *testing.T, hub *Hub, tokenSvc *service.TokenService) string {
+	t.Helper()
+	srv := httptest.NewServer(HandleWebSocket(hub, tokenSvc))
+	t.Cleanup(srv.Close)
+	return "ws" + strings.TrimPrefix(srv.URL, "http")
+}
+
+// TestHandleWebSocket_ValidAuth tests that a valid JWT auth message results in auth_ok.
+func TestHandleWebSocket_ValidAuth(t *testing.T) {
+	hub := newHandlerHub(t)
+	tokenSvc := newTestTokenService(t)
+	userID := uuid.New()
+	token := mintToken(t, tokenSvc, userID, model.RoleUser)
+
+	conn, _, err := websocket.Dial(context.Background(), serveWS(t, hub, tokenSvc), nil)
+	require.NoError(t, err)
+	defer conn.CloseNow()
+
+	require.NoError(t, wsjson.Write(context.Background(), conn, ClientMessage{
+		Type:  ClientMessageAuth,
+		Token: token,
+	}))
+
+	var msg ServerMessage
+	require.NoError(t, wsjson.Read(context.Background(), conn, &msg))
+	assert.Equal(t, ServerMessageAuthOk, msg.Type)
+	assert.NotEmpty(t, msg.ConnectionID)
+
+	// Verify client is registered under the correct userID.
+	hub.mu.RLock()
+	_, registered := hub.clients[userID.String()]
+	hub.mu.RUnlock()
+	assert.True(t, registered)
+}
+
+// TestHandleWebSocket_InvalidToken tests that an invalid token closes the connection.
+func TestHandleWebSocket_InvalidToken(t *testing.T) {
+	hub := newHandlerHub(t)
+	tokenSvc := newTestTokenService(t)
+
+	conn, _, err := websocket.Dial(context.Background(), serveWS(t, hub, tokenSvc), nil)
+	require.NoError(t, err)
+	defer conn.CloseNow()
+
+	require.NoError(t, wsjson.Write(context.Background(), conn, ClientMessage{
+		Type:  ClientMessageAuth,
+		Token: "not-a-valid-jwt",
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	var msg ServerMessage
+	err = wsjson.Read(ctx, conn, &msg)
+	assert.Error(t, err, "connection should be closed after invalid token")
+}
+
+// TestHandleWebSocket_WrongFirstMessageType tests that a non-auth first message closes the connection.
+func TestHandleWebSocket_WrongFirstMessageType(t *testing.T) {
+	hub := newHandlerHub(t)
+	tokenSvc := newTestTokenService(t)
+
+	conn, _, err := websocket.Dial(context.Background(), serveWS(t, hub, tokenSvc), nil)
+	require.NoError(t, err)
+	defer conn.CloseNow()
+
+	require.NoError(t, wsjson.Write(context.Background(), conn, ClientMessage{
+		Type: ClientMessagePing,
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	var msg ServerMessage
+	err = wsjson.Read(ctx, conn, &msg)
+	assert.Error(t, err, "connection should be closed when first message is not auth")
+}
+
+// TestHandleWebSocket_EmptyToken tests that an auth message with empty token is rejected.
+func TestHandleWebSocket_EmptyToken(t *testing.T) {
+	hub := newHandlerHub(t)
+	tokenSvc := newTestTokenService(t)
+
+	conn, _, err := websocket.Dial(context.Background(), serveWS(t, hub, tokenSvc), nil)
+	require.NoError(t, err)
+	defer conn.CloseNow()
+
+	require.NoError(t, wsjson.Write(context.Background(), conn, ClientMessage{
+		Type:  ClientMessageAuth,
+		Token: "",
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	var msg ServerMessage
+	err = wsjson.Read(ctx, conn, &msg)
+	assert.Error(t, err, "connection should be closed on empty token")
+}
+
+// TestHandleWebSocket_SubscribeAfterAuth tests the full auth → subscribe flow.
+func TestHandleWebSocket_SubscribeAfterAuth(t *testing.T) {
+	hub := newHandlerHub(t)
+	tokenSvc := newTestTokenService(t)
+	userID := uuid.New()
+	token := mintToken(t, tokenSvc, userID, model.RoleUser)
+
+	conn, _, err := websocket.Dial(context.Background(), serveWS(t, hub, tokenSvc), nil)
+	require.NoError(t, err)
+	defer conn.CloseNow()
+
+	// Auth
+	require.NoError(t, wsjson.Write(context.Background(), conn, ClientMessage{
+		Type:  ClientMessageAuth,
+		Token: token,
+	}))
+	var authOk ServerMessage
+	require.NoError(t, wsjson.Read(context.Background(), conn, &authOk))
+	assert.Equal(t, ServerMessageAuthOk, authOk.Type)
+
+	// Subscribe to own usage topic
+	topic := "usage:" + userID.String()
+	require.NoError(t, wsjson.Write(context.Background(), conn, ClientMessage{
+		Type:   ClientMessageSubscribe,
+		Topics: []string{topic},
+	}))
+	var subMsg ServerMessage
+	require.NoError(t, wsjson.Read(context.Background(), conn, &subMsg))
+	assert.Equal(t, ServerMessageSubscribed, subMsg.Type)
+	assert.Equal(t, []string{topic}, subMsg.Topics)
+}
+
+// TestHandleWebSocket_PingPong tests ping → pong after auth.
+func TestHandleWebSocket_PingPong(t *testing.T) {
+	hub := newHandlerHub(t)
+	tokenSvc := newTestTokenService(t)
+	userID := uuid.New()
+	token := mintToken(t, tokenSvc, userID, model.RoleUser)
+
+	conn, _, err := websocket.Dial(context.Background(), serveWS(t, hub, tokenSvc), nil)
+	require.NoError(t, err)
+	defer conn.CloseNow()
+
+	require.NoError(t, wsjson.Write(context.Background(), conn, ClientMessage{Type: ClientMessageAuth, Token: token}))
+	var authOk ServerMessage
+	require.NoError(t, wsjson.Read(context.Background(), conn, &authOk))
+
+	require.NoError(t, wsjson.Write(context.Background(), conn, ClientMessage{Type: ClientMessagePing}))
+	var pong ServerMessage
+	require.NoError(t, wsjson.Read(context.Background(), conn, &pong))
+	assert.Equal(t, ServerMessagePong, pong.Type)
+}
+
+// servePolling starts an httptest server running HandlePolling with userID/role injected into context.
+func servePolling(t *testing.T, hub *Hub, userID string, role model.UserRole) *httptest.Server {
+	t.Helper()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), middleware.UserIDKey, uuid.MustParse(userID))
+		ctx = context.WithValue(ctx, middleware.UserRoleKey, role)
+		HandlePolling(hub)(w, r.WithContext(ctx))
+	})
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestHandlePolling_EmptyTopics tests that an empty topics param returns an empty event list.
+func TestHandlePolling_EmptyTopics(t *testing.T) {
+	hub := newHandlerHub(t)
+	userID := uuid.New().String()
+	srv := servePolling(t, hub, userID, model.RoleUser)
+
+	resp, err := http.Get(srv.URL + "/api/realtime/updates")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body pollingResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Empty(t, body.Events)
+	assert.Empty(t, body.ResyncRequired)
+}
+
+// TestHandlePolling_ReturnsBufferedEvents tests events are returned for subscribed topics.
+func TestHandlePolling_ReturnsBufferedEvents(t *testing.T) {
+	hub := newHandlerHub(t)
+	userID := uuid.New()
+	topic := "usage:" + userID.String()
+
+	hub.buffer.Append(topic, 1, []byte(`{"amount":10}`))
+	hub.buffer.Append(topic, 2, []byte(`{"amount":20}`))
+
+	srv := servePolling(t, hub, userID.String(), model.RoleUser)
+
+	resp, err := http.Get(srv.URL + "/api/realtime/updates?topics=" + topic)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body pollingResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Len(t, body.Events, 2)
+	assert.Equal(t, uint64(2), body.CurrentSeq)
+	assert.Empty(t, body.ResyncRequired)
+}
+
+// TestHandlePolling_SinceSeq tests that since_seq filters older events.
+func TestHandlePolling_SinceSeq(t *testing.T) {
+	hub := newHandlerHub(t)
+	userID := uuid.New()
+	topic := "usage:" + userID.String()
+
+	hub.buffer.Append(topic, 1, []byte(`{"a":1}`))
+	hub.buffer.Append(topic, 2, []byte(`{"a":2}`))
+	hub.buffer.Append(topic, 3, []byte(`{"a":3}`))
+
+	srv := servePolling(t, hub, userID.String(), model.RoleUser)
+
+	resp, err := http.Get(srv.URL + "/api/realtime/updates?topics=" + topic + "&since_seq=1")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var body pollingResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Len(t, body.Events, 2) // seq 2 and 3
+	assert.Equal(t, uint64(3), body.CurrentSeq)
+}
+
+// TestHandlePolling_UnauthorizedTopicFiltered tests that events for another user's topic are not returned.
+func TestHandlePolling_UnauthorizedTopicFiltered(t *testing.T) {
+	hub := newHandlerHub(t)
+	owner := uuid.New()
+	requester := uuid.New()
+	topic := "usage:" + owner.String()
+
+	hub.buffer.Append(topic, 1, []byte(`{"amount":10}`))
+
+	srv := servePolling(t, hub, requester.String(), model.RoleUser)
+
+	resp, err := http.Get(srv.URL + "/api/realtime/updates?topics=" + topic)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var body pollingResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Empty(t, body.Events)
+}
+
+// TestHandlePolling_AdminSeesAll tests that an admin can poll any topic.
+func TestHandlePolling_AdminSeesAll(t *testing.T) {
+	hub := newHandlerHub(t)
+	owner := uuid.New()
+	admin := uuid.New()
+	topic := "usage:" + owner.String()
+
+	hub.buffer.Append(topic, 1, []byte(`{"amount":10}`))
+
+	srv := servePolling(t, hub, admin.String(), model.RoleAdmin)
+
+	resp, err := http.Get(srv.URL + "/api/realtime/updates?topics=" + topic)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var body pollingResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Len(t, body.Events, 1)
+}

--- a/backend/internal/api/realtime/hub.go
+++ b/backend/internal/api/realtime/hub.go
@@ -166,13 +166,20 @@ func (h *Hub) RefreshAuth(c *Client, _ string) {
 	c.Send(NewAuthOkMessage(c.id))
 }
 
-// PollEvents returns buffered events for the requested topics since sinceSeq.
-// Topics where the buffer was exceeded are returned in the resync list.
+// PollEntry is a buffered event with its topic attached, for polling responses.
+type PollEntry struct {
+	Topic string
+	SeqEntry
+}
+
+// PollResult is the return value of PollEvents.
 type PollResult struct {
-	Events         []SeqEntry
+	Events         []PollEntry
 	ResyncRequired []string
 }
 
+// PollEvents returns buffered events for the requested topics since sinceSeq.
+// Topics where the buffer was exceeded are returned in the resync list.
 func (h *Hub) PollEvents(userID string, role model.UserRole, topics []string, sinceSeq uint64) PollResult {
 	var result PollResult
 	for _, topic := range topics {
@@ -184,7 +191,9 @@ func (h *Hub) PollEvents(userID string, role model.UserRole, topics []string, si
 			result.ResyncRequired = append(result.ResyncRequired, topic)
 			continue
 		}
-		result.Events = append(result.Events, entries...)
+		for _, e := range entries {
+			result.Events = append(result.Events, PollEntry{Topic: topic, SeqEntry: e})
+		}
 	}
 	return result
 }

--- a/backend/internal/api/realtime/hub_test.go
+++ b/backend/internal/api/realtime/hub_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
-	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric/noop"
@@ -21,27 +20,11 @@ import (
 	"ace/internal/api/model"
 )
 
-// newTestHub creates a Hub without a real NATS connection for unit testing.
-// topicReg dispatch is wired to a no-op NATS stub so Add/Remove work on ref counts only.
 func newTestHub(t *testing.T) *Hub {
 	t.Helper()
 	logger, _ := zap.NewDevelopment()
 	meter := noop.NewMeterProvider().Meter("test")
-	h := &Hub{
-		clients: make(map[string][]*Client),
-		buffer:  NewSeqBuffer(DefaultSeqBufferConfig()),
-		logger:  logger,
-		meter:   meter,
-	}
-	// TopicReg with nil NATS — tests that call Add/Remove must use topics that
-	// won't attempt a real NATS Dial. We use a custom dispatch-only reg.
-	h.topics = &TopicReg{
-		refs:     make(map[string]int),
-		subs:     make(map[string]*nats.Subscription),
-		logger:   logger,
-		dispatch: h.dispatchNATSEvent,
-	}
-	return h
+	return NewHub(testNATSConn, logger, meter)
 }
 
 // dialTestHub starts an httptest server that upgrades to WebSocket and returns

--- a/backend/internal/api/realtime/main_test.go
+++ b/backend/internal/api/realtime/main_test.go
@@ -1,0 +1,36 @@
+package realtime
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+)
+
+var testNATSConn *nats.Conn
+
+func TestMain(m *testing.M) {
+	opts := &server.Options{Port: -1}
+	srv, err := server.NewServer(opts)
+	if err != nil {
+		panic("nats server: " + err.Error())
+	}
+	go srv.Start()
+	if !srv.ReadyForConnections(5 * time.Second) {
+		panic("nats server not ready")
+	}
+
+	testNATSConn, err = nats.Connect(srv.ClientURL())
+	if err != nil {
+		srv.Shutdown()
+		panic("nats connect: " + err.Error())
+	}
+
+	code := m.Run()
+
+	testNATSConn.Close()
+	srv.Shutdown()
+	os.Exit(code)
+}

--- a/backend/internal/api/realtime/topic.go
+++ b/backend/internal/api/realtime/topic.go
@@ -321,11 +321,7 @@ func (t *TopicReg) matchSubjectToTopic(subject, pattern string) (string, bool) {
 }
 
 // subscribeNATS creates a NATS subscription for the given subject.
-// Returns nil without error when nats is nil (test-only path).
 func (t *TopicReg) subscribeNATS(subject, topic string) (*nats.Subscription, error) {
-	if t.nats == nil {
-		return nil, nil
-	}
 	sub, err := messaging.SubscribeWithEnvelope(t.natsClient, subject, func(env *messaging.Envelope, data []byte) error {
 		if t.dispatch != nil {
 			t.dispatch(topic, data)

--- a/backend/internal/api/router/router.go
+++ b/backend/internal/api/router/router.go
@@ -17,6 +17,7 @@ import (
 	"ace/docs"
 	"ace/internal/api/handler"
 	mw "ace/internal/api/middleware"
+	"ace/internal/api/realtime"
 	db "ace/internal/api/repository/generated"
 	"ace/internal/api/service"
 	"ace/internal/caching"
@@ -56,6 +57,7 @@ type Config struct {
 	DB           *sql.DB
 	NATSConn     *nats.Conn
 	Cache        caching.CacheBackend
+	Hub          *realtime.Hub
 	SPAHandler   http.Handler // Serves the SPA (embedded assets or Vite proxy)
 }
 
@@ -192,6 +194,18 @@ func New(cfg *Config) (*chi.Mux, error) {
 			r.Get("/health", telemetryHandler.Health)
 		})
 	})
+
+	// Realtime routes
+	if cfg.Hub != nil {
+		// WebSocket — no auth middleware, auth via first message
+		r.Get("/api/ws", realtime.HandleWebSocket(cfg.Hub, cfg.TokenService))
+
+		// Polling — protected by auth middleware
+		r.Group(func(r chi.Router) {
+			r.Use(authMw.RequireAuth())
+			r.Get("/api/realtime/updates", realtime.HandlePolling(cfg.Hub))
+		})
+	}
 
 	// SPA catch-all route - must be last to not intercept API routes
 	if cfg.SPAHandler != nil {

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	db "ace/internal/api/repository/generated"
+	"ace/internal/api/realtime"
 	"ace/internal/api/router"
 	"ace/internal/api/service"
 	"ace/internal/caching"
@@ -38,6 +39,7 @@ type App struct {
 	Telemetry   *telemetry.Telemetry
 	HTTPServer  *http.Server
 	Router      *chi.Mux
+	Hub         *realtime.Hub
 	logger      *zap.Logger
 }
 
@@ -182,6 +184,9 @@ func (a *App) Serve() error {
 		return fmt.Errorf("create auth service: %w", err)
 	}
 
+	// Create realtime hub
+	a.Hub = realtime.NewHub(a.NATSConn, a.logger, a.Telemetry.Meter)
+
 	// Create router
 	routeCfg := &router.Config{
 		App: &router.AppConfig{
@@ -195,6 +200,7 @@ func (a *App) Serve() error {
 		DB:           a.DB,
 		NATSConn:     a.NATSConn,
 		Cache:        a.Cache,
+		Hub:          a.Hub,
 		SPAHandler:   frontend.Handler(),
 	}
 
@@ -243,7 +249,16 @@ func (a *App) Shutdown() error {
 		}
 	}
 
-	// 2. Stop pruning goroutine
+	// 2. Close realtime hub (drains WebSocket connections before NATS shuts down)
+	if a.Hub != nil {
+		if err := a.Hub.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close hub: %w", err))
+		} else {
+			a.logger.Info("realtime hub closed")
+		}
+	}
+
+	// 3. Stop pruning goroutine
 	if a.Telemetry != nil && a.Telemetry.PruneStop != nil {
 		a.Telemetry.PruneStop()
 		a.logger.Info("telemetry pruning stopped")


### PR DESCRIPTION
## Summary
- Adds `HandleWebSocket` — upgrades connection, 5s auth timeout, validates JWT via `TokenService`, creates `Client`, registers with Hub
- Adds `HandlePolling` — auth-middleware-protected `GET /api/realtime/updates?topics=...&since_seq=...`
- Wires `GET /api/ws` and `GET /api/realtime/updates` into router; `Hub` added to `router.Config`
- Creates `Hub` in app startup using `Telemetry.Meter`; `Hub.Close()` called in `Shutdown` before NATS drains
- Replaces nil-NATS guard (removed) with a proper `TestMain` embedding a real NATS server for the realtime package test suite

## Test plan
- [ ] `go test ./internal/api/realtime/...` passes with real in-process NATS
- [ ] `make test` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)