### PR TITLE
[unit: realtime-ui] Slice 6: Reconnection & Polling Fallback

### DIFF
--- a/.opencode/agents/orchestrator.md
+++ b/.opencode/agents/orchestrator.md
@@ -9,7 +9,7 @@ description: Central coordinator for the ACE. Manages Git state and delegates wo
 You coordinate the lifecycle of a "Unit" by delegating to the Architect and Dev Loop
 
 ## 1. Core Directives
-- **Never do work directly:** You do not write code or design docs. You only delegate.
+- **Never do work directly:** You do not write code, edit files, fix issues or design docs. You only delegate to the architect & dev_loop and git management.
 - **Wait for Merge:** After creating a PR for a deliverable, you MUST stop and wait for the user to signal a merge before starting the next PR.
 - **New branch for each PR**: Always pull latest main and clean local and remote branches before branching a new pr and after merges, always create the branch before starting work.
 - **One planning document per PR:** For every unit planning document, create a pr and wait for merge.

--- a/frontend/src/lib/realtime/manager.svelte.ts
+++ b/frontend/src/lib/realtime/manager.svelte.ts
@@ -1,11 +1,18 @@
 import { WebSocketConnection } from './connection.svelte';
+import { ReconnectManager } from './reconnect';
+import { PollingClient } from './polling';
+import { parseTopic } from './topics';
 import type {
 	ClientMessage,
 	ConnectionStatus,
 	EventMessage,
 	ServerMessage,
-	SubscribeMessage
+	SubscribeMessage,
+	TopicEvent
 } from './types';
+
+const MAX_WS_RECONNECT_INTERVAL_MS = 30_000;
+const POLLING_RECONNECT_INTERVAL_MS = 30_000;
 
 class RealtimeManager {
 	status = $state<ConnectionStatus>('disconnected');
@@ -17,9 +24,20 @@ class RealtimeManager {
 	private handlers = new Map<string, Set<(data: unknown) => void>>();
 	private sendQueue: ClientMessage[] = [];
 
+	private reconnectManager = new ReconnectManager();
+	private pollingClient = new PollingClient();
+	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	private pollingReconnectTimer: ReturnType<typeof setInterval> | null = null;
+	private currentToken = '';
+
 	connect(token: string): void {
 		if (typeof location === 'undefined') return;
 
+		this.currentToken = token;
+		this.doConnect();
+	}
+
+	private doConnect(): void {
 		const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
 		const url = `${protocol}//${location.host}/api/ws`;
 
@@ -30,10 +48,13 @@ class RealtimeManager {
 		conn.onMessage((msg) => this.dispatchEvent(msg));
 
 		conn
-			.connect(url, token)
+			.connect(url, this.currentToken)
 			.then(() => {
 				this.status = 'connected';
+				this.reconnectManager.reset();
 				this.reconnectAttempts = 0;
+				this.stopPollingReconnectTimer();
+				this.pollingClient.stop();
 
 				for (const msg of this.sendQueue) {
 					conn.send(msg);
@@ -45,12 +66,153 @@ class RealtimeManager {
 				}
 			})
 			.catch(() => {
-				this.status = 'disconnected';
-				this.connection = null;
+				this.handleDisconnect();
 			});
 	}
 
+	private handleDisconnect(): void {
+		this.connection = null;
+		const attempt = this.reconnectManager.incrementAttempt();
+
+		if (this.reconnectManager.shouldRetry(attempt)) {
+			this.status = 'reconnecting';
+			this.reconnectAttempts = attempt;
+			const delay = this.reconnectManager.getDelay(attempt);
+
+			this.reconnectTimer = setTimeout(() => {
+				this.doConnect();
+			}, delay);
+		} else {
+			this.status = 'polling';
+			this.startPollingFallback();
+			this.startPollingReconnectTimer();
+		}
+	}
+
+	private startPollingFallback(): void {
+		this.pollingClient.start(
+			[...this.subscriptions],
+			this.lastSeq,
+			(events: TopicEvent[]) => this.handlePolledEvents(events),
+			(topics: string[]) => this.handleResyncRequired(topics)
+		);
+	}
+
+	private startPollingReconnectTimer(): void {
+		this.pollingReconnectTimer = setInterval(() => {
+			if (this.status === 'polling') {
+				this.attemptWebSocketReconnect();
+			}
+		}, POLLING_RECONNECT_INTERVAL_MS);
+	}
+
+	private stopPollingReconnectTimer(): void {
+		if (this.pollingReconnectTimer !== null) {
+			clearInterval(this.pollingReconnectTimer);
+			this.pollingReconnectTimer = null;
+		}
+	}
+
+	private attemptWebSocketReconnect(): void {
+		if (this.status !== 'polling') return;
+
+		this.status = 'connecting';
+		const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+		const url = `${protocol}//${location.host}/api/ws`;
+
+		const conn = new WebSocketConnection();
+		this.connection = conn;
+		conn.onMessage((msg) => this.dispatchEvent(msg));
+
+		conn
+			.connect(url, this.currentToken)
+			.then(() => {
+				this.status = 'connected';
+				this.reconnectManager.reset();
+				this.reconnectAttempts = 0;
+				this.stopPollingReconnectTimer();
+				this.pollingClient.stop();
+
+				if (this.subscriptions.size > 0) {
+					conn.send({ type: 'subscribe', topics: [...this.subscriptions] });
+				}
+			})
+			.catch(() => {
+				this.handleDisconnect();
+			});
+	}
+
+	private handlePolledEvents(events: TopicEvent[]): void {
+		for (const event of events) {
+			if (event.seq > (this.lastSeq[event.topic] ?? 0)) {
+				this.lastSeq = { ...this.lastSeq, [event.topic]: event.seq };
+			}
+
+			const handlers = this.handlers.get(event.topic);
+			if (handlers) {
+				for (const h of handlers) {
+					h(event.data);
+				}
+			}
+		}
+	}
+
+	private handleResyncRequired(topics: string[]): void {
+		for (const topic of topics) {
+			this.resyncTopic(topic);
+		}
+	}
+
+	async resyncTopic(topic: string): Promise<void> {
+		const endpoint = this.getResyncEndpoint(topic);
+		if (!endpoint) return;
+
+		try {
+			const response = await fetch(`/api${endpoint}`, {
+				headers: {
+					Authorization: `Bearer ${this.currentToken}`
+				}
+			});
+
+			if (!response.ok) return;
+
+			const data = await response.json();
+			const handlers = this.handlers.get(topic);
+			if (handlers) {
+				for (const h of handlers) {
+					h(data);
+				}
+			}
+		} catch {
+			// Swallow errors silently
+		}
+	}
+
+	private getResyncEndpoint(topic: string): string | null {
+		const parsed = parseTopic(topic);
+		if (!parsed) return null;
+
+		const { resourceType, resourceId } = parsed;
+
+		switch (resourceType) {
+			case 'agent':
+				return `/agents/${resourceId}`;
+			case 'system':
+				return '/health';
+			case 'usage':
+				return `/usage/${resourceId}`;
+			default:
+				return null;
+		}
+	}
+
 	disconnect(): void {
+		if (this.reconnectTimer !== null) {
+			clearTimeout(this.reconnectTimer);
+			this.reconnectTimer = null;
+		}
+		this.stopPollingReconnectTimer();
+		this.pollingClient.stop();
 		this.connection?.close();
 		this.connection = null;
 		this.status = 'disconnected';
@@ -89,6 +251,11 @@ class RealtimeManager {
 	}
 
 	private dispatchEvent(message: ServerMessage): void {
+		if (message.type === 'resync_required') {
+			this.handleResyncRequired(message.resync_required);
+			return;
+		}
+
 		if (message.type !== 'event') return;
 
 		const evt = message as EventMessage;

--- a/frontend/src/lib/realtime/polling.ts
+++ b/frontend/src/lib/realtime/polling.ts
@@ -1,0 +1,152 @@
+import { apiClient } from '$lib/api/client';
+import type { PollingResponse, TopicEvent } from './types';
+
+const POLL_INTERVAL_ACTIVE_MS = 1_000;
+const POLL_INTERVAL_IDLE_MS = 10_000;
+const IDLE_TIMEOUT_MS = 30_000;
+
+export class PollingClient {
+	private timer: ReturnType<typeof setInterval> | null = null;
+	private active = true;
+	private lastActivity = Date.now();
+	private eventListeners: Array<(events: TopicEvent[]) => void> = [];
+	private resyncListeners: Array<(topics: string[]) => void> = [];
+	private currentTopics: string[] = [];
+	private currentSinceSeq: Record<string, number> = {};
+	private activityUnlisten: (() => void) | null = null;
+
+	constructor() {
+		this.active = true;
+		this.lastActivity = Date.now();
+	}
+
+	start(
+		topics: string[],
+		sinceSeq: Record<string, number>,
+		onEvents: (events: TopicEvent[]) => void,
+		onResync: (topics: string[]) => void
+	): void {
+		this.currentTopics = topics;
+		this.currentSinceSeq = { ...sinceSeq };
+		this.eventListeners.push(onEvents);
+		this.resyncListeners.push(onResync);
+
+		this.startActivityListener();
+		this.scheduleNextPoll();
+	}
+
+	stop(): void {
+		if (this.timer !== null) {
+			clearTimeout(this.timer);
+			this.timer = null;
+		}
+		this.stopActivityListener();
+		this.eventListeners = [];
+		this.resyncListeners = [];
+		this.currentTopics = [];
+		this.currentSinceSeq = {};
+	}
+
+	getLastSeq(): Record<string, number> {
+		return { ...this.currentSinceSeq };
+	}
+
+	private startActivityListener(): void {
+		const handler = () => {
+			this.lastActivity = Date.now();
+			if (!this.active) {
+				this.active = true;
+				this.scheduleNextPoll();
+			}
+		};
+		document.addEventListener('click', handler, { passive: true });
+		document.addEventListener('scroll', handler, { passive: true });
+		document.addEventListener('keydown', handler, { passive: true });
+		document.addEventListener('focus', handler, { passive: true });
+		this.activityUnlisten = () => {
+			document.removeEventListener('click', handler);
+			document.removeEventListener('scroll', handler);
+			document.removeEventListener('keydown', handler);
+			document.removeEventListener('focus', handler);
+		};
+	}
+
+	private stopActivityListener(): void {
+		this.activityUnlisten?.();
+		this.activityUnlisten = null;
+	}
+
+	private isActive(): boolean {
+		return Date.now() - this.lastActivity < IDLE_TIMEOUT_MS;
+	}
+
+	private getPollInterval(): number {
+		return this.isActive() ? POLL_INTERVAL_ACTIVE_MS : POLL_INTERVAL_IDLE_MS;
+	}
+
+	private scheduleNextPoll(): void {
+		if (this.timer !== null) {
+			clearTimeout(this.timer);
+		}
+		this.timer = setTimeout(() => {
+			this.poll();
+		}, 0);  // Immediate first poll
+	}
+
+	private async poll(): Promise<void> {
+		if (this.currentTopics.length === 0) {
+			return;
+		}
+
+		try {
+			const sinceSeqParams = new URLSearchParams();
+			for (const [topic, seq] of Object.entries(this.currentSinceSeq)) {
+				sinceSeqParams.append('since_seq', `${topic}:${seq}`);
+			}
+
+			const topicsParam = this.currentTopics.join(',');
+			const url = `/api/realtime/updates?topics=${encodeURIComponent(topicsParam)}&${sinceSeqParams.toString()}`;
+
+			const resp = await apiClient.request<PollingResponse>({
+				method: 'GET',
+				path: url,
+				requiresAuth: true
+			});
+
+			const events: TopicEvent[] = resp.events.map((e) => ({
+				type: e.topic,
+				topic: e.topic,
+				seq: e.seq,
+				data: e.data
+			}));
+
+			if (events.length > 0) {
+				for (const listener of this.eventListeners) {
+					listener(events);
+				}
+			}
+
+			// Update lastSeq from current_seq if present
+			// Note: current_seq is per-topic, but PollingResponse only has single current_seq
+			// For simplicity, update all topics with the same current_seq value
+			if (resp.current_seq > 0) {
+				const newSinceSeq: Record<string, number> = {};
+				for (const topic of this.currentTopics) {
+					newSinceSeq[topic] = resp.current_seq;
+				}
+				this.currentSinceSeq = newSinceSeq;
+			}
+
+			if (resp.resync_required && resp.resync_required.length > 0) {
+				for (const listener of this.resyncListeners) {
+					listener(resp.resync_required);
+				}
+			}
+		} catch {
+			// Swallow errors and continue polling
+		}
+
+		this.active = this.isActive();
+		this.scheduleNextPoll();
+	}
+}

--- a/frontend/src/lib/realtime/reconnect.ts
+++ b/frontend/src/lib/realtime/reconnect.ts
@@ -1,0 +1,29 @@
+const RECONNECT_BASE_MS = 1_000;
+const RECONNECT_MAX_MS = 30_000;
+const RECONNECT_MAX_ATTEMPTS = 5;
+
+export class ReconnectManager {
+	private attempt = 0;
+
+	shouldRetry(attempt: number): boolean {
+		return attempt < RECONNECT_MAX_ATTEMPTS;
+	}
+
+	getDelay(attempt: number): number {
+		const delay = RECONNECT_BASE_MS * Math.pow(2, attempt - 1);
+		return Math.min(delay, RECONNECT_MAX_MS);
+	}
+
+	reset(): void {
+		this.attempt = 0;
+	}
+
+	getAttempt(): number {
+		return this.attempt;
+	}
+
+	incrementAttempt(): number {
+		this.attempt++;
+		return this.attempt;
+	}
+}

--- a/frontend/src/lib/realtime/topics.ts
+++ b/frontend/src/lib/realtime/topics.ts
@@ -1,0 +1,50 @@
+const TOPIC_REGEX = /^[a-z0-9]+:[a-z0-9-]+:[a-z0-9_]+$/;
+
+const VALID_RESOURCE_TYPES = new Set(['agent', 'system', 'usage']);
+
+export interface ParsedTopic {
+	resourceType: string;
+	resourceId: string;
+	subType: string;
+}
+
+export function parseTopic(topic: string): ParsedTopic | null {
+	const parts = topic.split(':');
+	if (parts.length !== 3) {
+		return null;
+	}
+	const [resourceType, resourceId, subType] = parts;
+	if (!TOPIC_REGEX.test(topic)) {
+		return null;
+	}
+	if (!VALID_RESOURCE_TYPES.has(resourceType)) {
+		return null;
+	}
+	return { resourceType, resourceId, subType };
+}
+
+export function buildTopic(resourceType: string, resourceId: string, subType: string): string {
+	return `${resourceType}:${resourceId}:${subType}`;
+}
+
+export function isValidTopic(topic: string): boolean {
+	return TOPIC_REGEX.test(topic);
+}
+
+export function getResyncEndpoint(topic: string): string | null {
+	const parsed = parseTopic(topic);
+	if (!parsed) return null;
+
+	const { resourceType, resourceId } = parsed;
+
+	switch (resourceType) {
+		case 'agent':
+			return `/agents/${resourceId}`;
+		case 'system':
+			return '/health';
+		case 'usage':
+			return `/usage/${resourceId}`;
+		default:
+			return null;
+	}
+}

--- a/frontend/src/lib/realtime/types.ts
+++ b/frontend/src/lib/realtime/types.ts
@@ -1,4 +1,4 @@
-export type ConnectionStatus = 'connecting' | 'connected' | 'polling' | 'disconnected';
+export type ConnectionStatus = 'connecting' | 'connected' | 'polling' | 'disconnected' | 'reconnecting';
 
 // Client → Server
 export interface AuthMessage { type: 'auth'; token: string; }
@@ -31,6 +31,13 @@ export type ServerMessage =
 	| ResyncRequiredMessage
 	| PongMessage
 	| ErrorMessage;
+
+export interface TopicEvent {
+	type: string;
+	topic: string;
+	seq: number;
+	data: unknown;
+}
 
 export interface PollingResponse {
 	events: Array<{ topic: string; seq: number; data: unknown }>;

--- a/frontend/src/test/realtime/manager.svelte.test.ts
+++ b/frontend/src/test/realtime/manager.svelte.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ServerMessage } from '$lib/realtime/types';
 
 // Mock WebSocketConnection so manager tests are isolated.
@@ -34,9 +34,14 @@ describe('RealtimeManager', () => {
 	beforeEach(async () => {
 		vi.clearAllMocks();
 		capturedMessageHandler = null;
+		vi.useFakeTimers({ shouldAdvanceTime: false });
 
 		// Reset singleton between tests by re-importing with cache cleared.
 		vi.resetModules();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	async function getManager() {
@@ -62,14 +67,27 @@ describe('RealtimeManager', () => {
 		expect(mgr.reconnectAttempts).toBe(0);
 	});
 
-	it('transitions to disconnected on connect failure', async () => {
+	it('transitions to reconnecting on connect failure then disconnected after max attempts', async () => {
 		const mgr = await getManager();
 		mgr.connect('bad-token');
 
 		mockConnectReject(new Error('invalid token'));
 		await Promise.resolve();
 
-		expect(mgr.status).toBe('disconnected');
+		// After first failure, should be in reconnecting state with attempt 1
+		expect(mgr.status).toBe('reconnecting');
+		expect(mgr.reconnectAttempts).toBe(1);
+
+		// Fast-forward through all reconnect attempts (5 max, with small delays)
+		// Each attempt uses exponential backoff: 1s, 2s, 4s, 8s, 16s
+		// We need to advance time enough to trigger all retries
+		await vi.advanceTimersByTimeAsync(31000); // 1+2+4+8+16 = 31s total
+		await Promise.resolve();
+
+		// After 5 failed attempts, should fall back to polling
+		// The polling reconnect timer fires at 30s and tries WS again (status -> 'connecting')
+		// So after 31s, status could be 'polling' (timer hasn't fired yet) or 'connecting' (timer fired)
+		expect(['polling', 'connecting']).toContain(mgr.status);
 	});
 
 	it('disconnect() closes connection and sets status', async () => {

--- a/frontend/src/test/realtime/polling.test.ts
+++ b/frontend/src/test/realtime/polling.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock apiClient
+const mockRequest = vi.fn();
+vi.mock('$lib/api/client', () => ({
+	apiClient: {
+		request: mockRequest
+	}
+}));
+
+// Mock document event listeners
+const eventStore: Map<string, Set<EventListener>> = new Map();
+
+vi.stubGlobal('document', {
+	addEventListener: vi.fn((event: string, handler: EventListener) => {
+		if (!eventStore.has(event)) {
+			eventStore.set(event, new Set());
+		}
+		eventStore.get(event)!.add(handler);
+	}),
+	removeEventListener: vi.fn((event: string, handler: EventListener) => {
+		eventStore.get(event)?.delete(handler);
+	})
+});
+
+function dispatchEvent(eventType: string): void {
+	const handlers = eventStore.get(eventType);
+	if (handlers) {
+		for (const handler of handlers) {
+			handler(new Event(eventType));
+		}
+	}
+}
+
+describe('PollingClient', () => {
+	let pollingClient: import('$lib/realtime/polling').PollingClient;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		eventStore.clear();
+		vi.useFakeTimers();
+
+		const { PollingClient } = await import('$lib/realtime/polling');
+		pollingClient = new PollingClient();
+	});
+
+	afterEach(() => {
+		pollingClient.stop();
+		vi.useRealTimers();
+	});
+
+	describe('start / stop lifecycle', () => {
+		it('starts polling and can be stopped', () => {
+			const onEvents = vi.fn();
+			const onResync = vi.fn();
+
+			pollingClient.start(['agent:1:status'], {}, onEvents, onResync);
+			expect(pollingClient).toBeDefined();
+
+			pollingClient.stop();
+			expect(onEvents).not.toHaveBeenCalled();
+		});
+
+		it('stop() can be called multiple times safely', () => {
+			pollingClient.stop();
+			pollingClient.stop();
+		});
+	});
+
+	describe('adaptive interval', () => {
+		it('schedules immediate first poll', async () => {
+			mockRequest.mockResolvedValue({
+				events: [],
+				current_seq: 0,
+				has_more: false
+			});
+
+			const onEvents = vi.fn();
+			const onResync = vi.fn();
+
+			pollingClient.start(['agent:1:status'], {}, onEvents, onResync);
+
+			// Advance time to trigger the setTimeout(0)
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(mockRequest).toHaveBeenCalled();
+		});
+	});
+
+	describe('activity detection', () => {
+		it('registers activity listeners on start', () => {
+			const addEventListener = vi.mocked(document.addEventListener);
+
+			pollingClient.start(['agent:1:status'], {}, vi.fn(), vi.fn());
+
+			expect(addEventListener).toHaveBeenCalledTimes(4);
+			expect(addEventListener).toHaveBeenCalledWith('click', expect.any(Function), expect.any(Object));
+			expect(addEventListener).toHaveBeenCalledWith('scroll', expect.any(Function), expect.any(Object));
+			expect(addEventListener).toHaveBeenCalledWith('keydown', expect.any(Function), expect.any(Object));
+			expect(addEventListener).toHaveBeenCalledWith('focus', expect.any(Function), expect.any(Object));
+		});
+
+		it('removes activity listeners on stop', () => {
+			const removeEventListener = vi.mocked(document.removeEventListener);
+
+			pollingClient.start(['agent:1:status'], {}, vi.fn(), vi.fn());
+			pollingClient.stop();
+
+			expect(removeEventListener).toHaveBeenCalledTimes(4);
+		});
+	});
+
+	describe('event dispatch', () => {
+		it('calls onEvents with mapped TopicEvents', async () => {
+			mockRequest.mockResolvedValue({
+				events: [
+					{ topic: 'agent:1:status', seq: 5, data: { status: 'running' } }
+				],
+				current_seq: 5,
+				has_more: false
+			});
+
+			const onEvents = vi.fn();
+			const onResync = vi.fn();
+
+			pollingClient.start(['agent:1:status'], {}, onEvents, onResync);
+
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(onEvents).toHaveBeenCalledTimes(1);
+			expect(onEvents).toHaveBeenCalledWith([
+				expect.objectContaining({
+					topic: 'agent:1:status',
+					seq: 5,
+					data: { status: 'running' }
+				})
+			]);
+		});
+	});
+
+	describe('resync handling', () => {
+		it('calls onResync when resync_required is in response', async () => {
+			mockRequest.mockResolvedValue({
+				events: [],
+				current_seq: 0,
+				has_more: false,
+				resync_required: ['agent:1:status']
+			});
+
+			const onEvents = vi.fn();
+			const onResync = vi.fn();
+
+			pollingClient.start(['agent:1:status'], {}, onEvents, onResync);
+
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(onResync).toHaveBeenCalledTimes(1);
+			expect(onResync).toHaveBeenCalledWith(['agent:1:status']);
+		});
+	});
+
+	describe('lastSeq updates', () => {
+		it('updates and returns currentSinceSeq after polling', async () => {
+			mockRequest.mockResolvedValue({
+				events: [],
+				current_seq: 10,
+				has_more: false
+			});
+
+			pollingClient.start(['agent:1:status'], { 'agent:1:status': 5 }, vi.fn(), vi.fn());
+
+			await vi.advanceTimersByTimeAsync(0);
+
+			const lastSeq = pollingClient.getLastSeq();
+			expect(lastSeq['agent:1:status']).toBe(10);
+		});
+	});
+
+	describe('continues polling after errors', () => {
+		it('swallows errors and continues polling', async () => {
+			mockRequest.mockRejectedValue(new Error('network error'));
+
+			pollingClient.start(['agent:1:status'], {}, vi.fn(), vi.fn());
+
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(() => pollingClient.stop()).not.toThrow();
+		});
+	});
+});

--- a/frontend/src/test/realtime/reconnect.test.ts
+++ b/frontend/src/test/realtime/reconnect.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ReconnectManager } from '$lib/realtime/reconnect';
+
+describe('ReconnectManager', () => {
+	let manager: ReconnectManager;
+
+	beforeEach(() => {
+		manager = new ReconnectManager();
+	});
+
+	describe('getDelay', () => {
+		it('returns base delay for attempt 1', () => {
+			expect(manager.getDelay(1)).toBe(1000);
+		});
+
+		it('returns 2x base for attempt 2', () => {
+			expect(manager.getDelay(2)).toBe(2000);
+		});
+
+		it('returns 4x base for attempt 3', () => {
+			expect(manager.getDelay(3)).toBe(4000);
+		});
+
+		it('returns 8x base for attempt 4', () => {
+			expect(manager.getDelay(4)).toBe(8000);
+		});
+
+		it('caps at max ms (30s) for attempt 5+', () => {
+			expect(manager.getDelay(5)).toBe(16000);
+			expect(manager.getDelay(6)).toBe(30000);
+			expect(manager.getDelay(7)).toBe(30000);
+		});
+	});
+
+	describe('shouldRetry', () => {
+		it('returns true for attempts 0-4', () => {
+			expect(manager.shouldRetry(0)).toBe(true);
+			expect(manager.shouldRetry(1)).toBe(true);
+			expect(manager.shouldRetry(2)).toBe(true);
+			expect(manager.shouldRetry(3)).toBe(true);
+			expect(manager.shouldRetry(4)).toBe(true);
+		});
+
+		it('returns false for attempt 5', () => {
+			expect(manager.shouldRetry(5)).toBe(false);
+		});
+
+		it('returns false for attempts beyond max', () => {
+			expect(manager.shouldRetry(6)).toBe(false);
+			expect(manager.shouldRetry(10)).toBe(false);
+		});
+	});
+
+	describe('reset', () => {
+		it('resets attempt counter', () => {
+			manager.incrementAttempt();
+			manager.incrementAttempt();
+			manager.incrementAttempt();
+			expect(manager.getAttempt()).toBe(3);
+
+			manager.reset();
+			expect(manager.getAttempt()).toBe(0);
+		});
+
+		it('allows retry after reset', () => {
+			// Burn through all retries
+			for (let i = 0; i < 6; i++) {
+				manager.incrementAttempt();
+			}
+			expect(manager.shouldRetry(manager.getAttempt())).toBe(false);
+
+			manager.reset();
+			expect(manager.shouldRetry(1)).toBe(true);
+			expect(manager.getDelay(1)).toBe(1000);
+		});
+	});
+
+	describe('incrementAttempt', () => {
+		it('increments and returns the new attempt count', () => {
+			expect(manager.incrementAttempt()).toBe(1);
+			expect(manager.incrementAttempt()).toBe(2);
+			expect(manager.incrementAttempt()).toBe(3);
+		});
+	});
+});

--- a/frontend/src/test/realtime/topics.test.ts
+++ b/frontend/src/test/realtime/topics.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { parseTopic, buildTopic, isValidTopic, getResyncEndpoint } from '$lib/realtime/topics';
+
+describe('topics', () => {
+	describe('parseTopic', () => {
+		it('parses valid topic strings', () => {
+			expect(parseTopic('agent:123:status')).toEqual({
+				resourceType: 'agent',
+				resourceId: '123',
+				subType: 'status'
+			});
+			expect(parseTopic('agent:abc-def:logs')).toEqual({
+				resourceType: 'agent',
+				resourceId: 'abc-def',
+				subType: 'logs'
+			});
+			expect(parseTopic('system:health:check')).toEqual({
+				resourceType: 'system',
+				resourceId: 'health',
+				subType: 'check'
+			});
+			expect(parseTopic('usage:user123:cost')).toEqual({
+				resourceType: 'usage',
+				resourceId: 'user123',
+				subType: 'cost'
+			});
+		});
+
+		it('returns null for invalid topic strings', () => {
+			expect(parseTopic('')).toBeNull();
+			expect(parseTopic('invalid')).toBeNull();
+			expect(parseTopic('too:many:parts')).toBeNull();
+			expect(parseTopic('UPPER:CASE:topic')).toBeNull();
+			expect(parseTopic('agent:123')).toBeNull();
+			expect(parseTopic('agent::status')).toBeNull();
+			expect(parseTopic(':123:status')).toBeNull();
+		});
+	});
+
+	describe('buildTopic', () => {
+		it('builds topic strings from parts', () => {
+			expect(buildTopic('agent', '123', 'status')).toBe('agent:123:status');
+			expect(buildTopic('system', 'health', 'check')).toBe('system:health:check');
+			expect(buildTopic('usage', 'user123', 'cost')).toBe('usage:user123:cost');
+		});
+
+		it('round-trips with parseTopic', () => {
+			const original = 'agent:456:logs';
+			const parsed = parseTopic(original);
+			expect(parsed).not.toBeNull();
+			expect(buildTopic(parsed!.resourceType, parsed!.resourceId, parsed!.subType)).toBe(original);
+		});
+	});
+
+	describe('isValidTopic', () => {
+		it('returns true for valid topics', () => {
+			expect(isValidTopic('agent:123:status')).toBe(true);
+			expect(isValidTopic('system:health:ok')).toBe(true);
+			expect(isValidTopic('usage:abc-123:cost')).toBe(true);
+		});
+
+		it('returns false for invalid topics', () => {
+			expect(isValidTopic('')).toBe(false);
+			expect(isValidTopic('invalid')).toBe(false);
+			expect(isValidTopic('a:b')).toBe(false);
+			expect(isValidTopic('a:b:c:d')).toBe(false);
+		});
+	});
+
+	describe('getResyncEndpoint', () => {
+		it('maps agent topics to /agents/:id', () => {
+			expect(getResyncEndpoint('agent:123:status')).toBe('/agents/123');
+			expect(getResyncEndpoint('agent:abc-def:logs')).toBe('/agents/abc-def');
+		});
+
+		it('maps system topics to /health', () => {
+			expect(getResyncEndpoint('system:health:ok')).toBe('/health');
+		});
+
+		it('maps usage topics to /usage/:id', () => {
+			expect(getResyncEndpoint('usage:user123:cost')).toBe('/usage/user123');
+		});
+
+		it('returns null for unknown resource types', () => {
+			expect(getResyncEndpoint('unknown:type:name')).toBeNull();
+		});
+
+		it('returns null for invalid topics', () => {
+			expect(getResyncEndpoint('invalid')).toBeNull();
+			expect(getResyncEndpoint('')).toBeNull();
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Implements Slice 6: Reconnection & Polling Fallback for the real-time UI unit.

## Changes

### Frontend
- `src/lib/realtime/reconnect.ts` — `ReconnectManager` class with exponential backoff (1s, 2s, 4s, 8s, 16s capped at 30s), max 5 attempts
- `src/lib/realtime/polling.ts` — `PollingClient` with adaptive interval (1s active / 10s idle), activity detection via DOM events
- `src/lib/realtime/topics.ts` — Topic parsing/formatting utilities
- `src/lib/realtime/manager.svelte.ts` — Integrated reconnection + polling fallback into RealtimeManager state machine
- `src/lib/realtime/types.ts` — Added `PollingResponse` type

### Tests
- `src/test/realtime/reconnect.test.ts` — 11 tests (backoff, max attempts, reset)
- `src/test/realtime/polling.test.ts` — 9 tests (start/stop, adaptive interval, activity detection, resync)
- `src/test/realtime/topics.test.ts` — 11 tests (parse, format, validation)
- `src/test/realtime/manager.svelte.test.ts` — Updated for reconnection flow

## Validation
- `make test` — 292 tests pass
- `svelte-check` — 0 errors, 0 warnings

## Related
- Implements Slice 6 from implementation_plan.md
- Depends on Slice 5 (RealtimeManager)