### PR TITLE
[unit: realtime-ui] Slice 8: Agent Store Integration

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,4 +1,4 @@
-import type { APIEnvelope, APIError } from './types';
+import type { APIEnvelope, APIError, Agent } from './types';
 import { AUTH } from '$lib/utils/constants';
 
 export interface RequestOptions {
@@ -204,6 +204,20 @@ class APIClient {
 		}
 
 		return envelope.data as T;
+	}
+
+	listAgents(): Promise<Agent[]> {
+		return this.request<Agent[]>({
+			method: 'GET',
+			path: '/agents'
+		});
+	}
+
+	getAgent(id: string): Promise<Agent> {
+		return this.request<Agent>({
+			method: 'GET',
+			path: `/agents/${id}`
+		});
 	}
 }
 

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -89,6 +89,30 @@ export interface UsersListResponse {
 }
 
 // --- Sessions ---
+// --- Agents ---
+export interface Agent {
+	id: string;
+	name: string;
+	status: 'idle' | 'running' | 'paused' | 'error';
+	owner_id: string;
+	created_at: string;
+	updated_at: string;
+	metadata?: Record<string, unknown>;
+	current_cycle_id?: string;
+	cycle_started_at?: string;
+	last_cycle_id?: string;
+	cycle_completed_at?: string;
+	last_cycle_output?: unknown;
+}
+
+export interface AgentsListResponse {
+	agents: Agent[];
+	total: number;
+	page: number;
+	limit: number;
+}
+
+// --- Sessions ---
 export interface Session {
 	id: string;
 	user_id: string;

--- a/frontend/src/lib/realtime/connection.svelte.ts
+++ b/frontend/src/lib/realtime/connection.svelte.ts
@@ -86,6 +86,12 @@ export class WebSocketConnection {
 		this.status = 'disconnected';
 	}
 
+	sendAuth(token: string): void {
+		if (this.ws?.readyState === WebSocket.OPEN) {
+			this.ws.send(JSON.stringify({ type: 'auth', token }));
+		}
+	}
+
 	private handleMessage(event: MessageEvent): void {
 		let msg: ServerMessage;
 		try {

--- a/frontend/src/lib/realtime/manager.svelte.ts
+++ b/frontend/src/lib/realtime/manager.svelte.ts
@@ -154,6 +154,16 @@ class RealtimeManager {
 					h(event.data);
 				}
 			}
+
+			const eventPayload = event.data as { event_type?: string; data?: unknown };
+			if (eventPayload.event_type) {
+				const typeHandlers = this.handlers.get(eventPayload.event_type);
+				if (typeHandlers) {
+					for (const h of typeHandlers) {
+						h(eventPayload.data ?? event.data);
+					}
+				}
+			}
 		}
 	}
 
@@ -219,6 +229,14 @@ class RealtimeManager {
 		this.sendQueue = [];
 	}
 
+	// Send new auth token on existing connection without reconnecting
+	refreshAuth(token: string): void {
+		this.currentToken = token;
+		if (this.connection && this.status === 'connected') {
+			this.connection.sendAuth(token);
+		}
+	}
+
 	subscribe(topics: string[]): void {
 		for (const topic of topics) {
 			this.subscriptions.add(topic);
@@ -263,10 +281,21 @@ class RealtimeManager {
 			this.lastSeq = { ...this.lastSeq, [evt.topic]: evt.seq };
 		}
 
-		const handlers = this.handlers.get(evt.topic);
-		if (handlers) {
-			for (const h of handlers) {
+		const topicHandlers = this.handlers.get(evt.topic);
+		if (topicHandlers) {
+			for (const h of topicHandlers) {
 				h(evt.data);
+			}
+		}
+
+		// Also dispatch to event_type handlers (e.g., "agent.status_change")
+		const eventPayload = evt.data as { event_type?: string; data?: unknown };
+		if (eventPayload.event_type) {
+			const typeHandlers = this.handlers.get(eventPayload.event_type);
+			if (typeHandlers) {
+				for (const h of typeHandlers) {
+					h(eventPayload.data ?? evt.data);
+				}
 			}
 		}
 	}

--- a/frontend/src/lib/stores/agents.svelte.ts
+++ b/frontend/src/lib/stores/agents.svelte.ts
@@ -1,0 +1,126 @@
+import { realtimeManager } from '$lib/realtime/manager.svelte';
+import { apiClient } from '$lib/api/client';
+import type { Agent } from '$lib/api/types';
+
+export interface AgentStatusData {
+	agent_id: string;
+	status: string;
+	metadata?: Record<string, unknown>;
+}
+
+export interface AgentCycleStartData {
+	agent_id: string;
+	cycle_id: string;
+	started_at: string;
+}
+
+export interface AgentCycleCompleteData {
+	agent_id: string;
+	cycle_id: string;
+	completed_at: string;
+	output?: unknown;
+}
+
+class AgentStore {
+	agents = $state<Agent[]>([]);
+	loading = $state(false);
+	error = $state<string | null>(null);
+
+	private unsubscribers: (() => void)[] = [];
+	private subscribedTopics = new Set<string>();
+
+	init(): Promise<void> {
+		this.loading = true;
+		this.error = null;
+
+		return this.fetchAgents()
+			.then(() => this.subscribeToAgentTopics())
+			.finally(() => {
+				this.loading = false;
+			});
+	}
+
+	private async fetchAgents(): Promise<void> {
+		try {
+			const agents = await apiClient.request<Agent[]>({
+				method: 'GET',
+				path: '/agents'
+			});
+			this.agents = agents;
+		} catch (err) {
+			this.error = err instanceof Error ? err.message : 'Failed to fetch agents';
+		}
+	}
+
+	private subscribeToAgentTopics(): void {
+		for (const agent of this.agents) {
+			const topic = `agent:${agent.id}:status`;
+			this.subscribedTopics.add(topic);
+		}
+
+		if (this.subscribedTopics.size > 0) {
+			realtimeManager.subscribe([...this.subscribedTopics]);
+		}
+
+		const unsubStatusChange = realtimeManager.on(
+			'agent.status_change',
+			(data) => this.handleStatusChange(data as AgentStatusData)
+		);
+		this.unsubscribers.push(unsubStatusChange);
+
+		const unsubCycleStart = realtimeManager.on(
+			'agent.cycle_start',
+			(data) => this.handleCycleStart(data as AgentCycleStartData)
+		);
+		this.unsubscribers.push(unsubCycleStart);
+
+		const unsubCycleComplete = realtimeManager.on(
+			'agent.cycle_complete',
+			(data) => this.handleCycleComplete(data as AgentCycleCompleteData)
+		);
+		this.unsubscribers.push(unsubCycleComplete);
+	}
+
+	handleStatusChange(data: AgentStatusData): void {
+		const agent = this.agents.find((a) => a.id === data.agent_id);
+		if (agent) {
+			agent.status = data.status as Agent['status'];
+			if (data.metadata) {
+				agent.metadata = { ...agent.metadata, ...data.metadata };
+			}
+		}
+	}
+
+	handleCycleStart(data: AgentCycleStartData): void {
+		const agent = this.agents.find((a) => a.id === data.agent_id);
+		if (agent) {
+			agent.current_cycle_id = data.cycle_id;
+			agent.cycle_started_at = data.started_at;
+		}
+	}
+
+	handleCycleComplete(data: AgentCycleCompleteData): void {
+		const agent = this.agents.find((a) => a.id === data.agent_id);
+		if (agent) {
+			agent.last_cycle_id = data.cycle_id;
+			agent.cycle_completed_at = data.completed_at;
+			if (data.output) {
+				agent.last_cycle_output = data.output;
+			}
+		}
+	}
+
+	destroy(): void {
+		for (const unsub of this.unsubscribers) {
+			unsub();
+		}
+		this.unsubscribers = [];
+
+		if (this.subscribedTopics.size > 0) {
+			realtimeManager.unsubscribe([...this.subscribedTopics]);
+		}
+		this.subscribedTopics.clear();
+	}
+}
+
+export const agentStore = new AgentStore();

--- a/frontend/src/lib/stores/auth.svelte.ts
+++ b/frontend/src/lib/stores/auth.svelte.ts
@@ -125,6 +125,7 @@ class AuthStore {
 		try {
 			const response = await authApi.refresh(this.refreshToken);
 			this.handleTokenResponse(response);
+			realtimeManager.refreshAuth(response.access_token);
 		} catch {
 			this.clear();
 			goto(ROUTES.LOGIN);

--- a/frontend/src/routes/(app)/+page.svelte
+++ b/frontend/src/routes/(app)/+page.svelte
@@ -1,11 +1,22 @@
 <script lang="ts">
 	import { authStore } from '$lib/stores/auth.svelte';
+	import { agentStore } from '$lib/stores/agents.svelte';
 	import { ROUTES } from '$lib/utils/constants';
 	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import { Activity, Users, User, ArrowRight } from 'lucide-svelte';
 
 	let username = $derived(authStore.user?.username ?? 'User');
+
+	$effect(() => {
+		if (authStore.isAuthenticated) {
+			agentStore.init();
+		}
+
+		return () => {
+			agentStore.destroy();
+		};
+	});
 </script>
 
 <div class="space-y-6">

--- a/frontend/src/test/stores/agents.svelte.test.ts
+++ b/frontend/src/test/stores/agents.svelte.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('$lib/api/client', () => ({
+	apiClient: {
+		request: vi.fn(),
+		listAgents: vi.fn(),
+		getAgent: vi.fn()
+	}
+}));
+
+vi.mock('$lib/realtime/manager.svelte', () => ({
+	realtimeManager: {
+		subscribe: vi.fn(),
+		unsubscribe: vi.fn(),
+		on: vi.fn().mockReturnValue(() => {})
+	}
+}));
+
+describe('AgentStore', () => {
+	let agentStore: {
+		agents: unknown[];
+		loading: unknown;
+		error: unknown;
+		init: () => Promise<void>;
+		destroy: () => void;
+		handleStatusChange: (data: { agent_id: string; status: string; metadata?: Record<string, unknown> }) => void;
+		handleCycleStart: (data: { agent_id: string; cycle_id: string; started_at: string }) => void;
+		handleCycleComplete: (data: { agent_id: string; cycle_id: string; completed_at: string; output?: unknown }) => void;
+	};
+
+	const mockAgents = [
+		{
+			id: 'agent-1',
+			name: 'Test Agent 1',
+			status: 'idle' as const,
+			owner_id: 'user-1',
+			created_at: '2024-01-01T00:00:00Z',
+			updated_at: '2024-01-01T00:00:00Z'
+		},
+		{
+			id: 'agent-2',
+			name: 'Test Agent 2',
+			status: 'running' as const,
+			owner_id: 'user-1',
+			created_at: '2024-01-01T00:00:00Z',
+			updated_at: '2024-01-01T00:00:00Z'
+		}
+	];
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		const mod = await import('$lib/stores/agents.svelte');
+		agentStore = mod.agentStore as unknown as typeof agentStore;
+		agentStore.agents = [];
+		agentStore.loading = false;
+		agentStore.error = null;
+	});
+
+	describe('init', () => {
+		it('fetches agents via REST and subscribes to topics', async () => {
+			const { apiClient } = await import('$lib/api/client');
+			const { realtimeManager } = await import('$lib/realtime/manager.svelte');
+
+			vi.mocked(apiClient.request).mockResolvedValue(mockAgents);
+
+			await agentStore.init();
+
+			expect(apiClient.request).toHaveBeenCalledWith({
+				method: 'GET',
+				path: '/agents'
+			});
+			expect(realtimeManager.subscribe).toHaveBeenCalledWith([
+				'agent:agent-1:status',
+				'agent:agent-2:status'
+			]);
+			expect(agentStore.agents).toEqual(mockAgents);
+			expect(agentStore.loading).toBe(false);
+		});
+
+		it('sets error on fetch failure', async () => {
+			const { apiClient } = await import('$lib/api/client');
+
+			vi.mocked(apiClient.request).mockRejectedValue(new Error('Network error'));
+
+			await agentStore.init();
+
+			expect(agentStore.error).toBe('Network error');
+			expect(agentStore.loading).toBe(false);
+		});
+
+		it('registers handlers for agent events', async () => {
+			const { apiClient } = await import('$lib/api/client');
+			const { realtimeManager } = await import('$lib/realtime/manager.svelte');
+
+			vi.mocked(apiClient.request).mockResolvedValue(mockAgents);
+
+			await agentStore.init();
+
+			expect(realtimeManager.on).toHaveBeenCalledWith(
+				'agent.status_change',
+				expect.any(Function)
+			);
+			expect(realtimeManager.on).toHaveBeenCalledWith(
+				'agent.cycle_start',
+				expect.any(Function)
+			);
+			expect(realtimeManager.on).toHaveBeenCalledWith(
+				'agent.cycle_complete',
+				expect.any(Function)
+			);
+		});
+	});
+
+	describe('handleStatusChange', () => {
+		it('updates agent status in-place', async () => {
+			agentStore.agents = [...mockAgents];
+
+			agentStore.handleStatusChange({
+				agent_id: 'agent-1',
+				status: 'running'
+			});
+
+			const agent = agentStore.agents.find((a: unknown) => (a as { id: string }).id === 'agent-1');
+			expect((agent as { status: string }).status).toBe('running');
+		});
+
+		it('updates metadata when provided', async () => {
+			agentStore.agents = [...mockAgents];
+
+			agentStore.handleStatusChange({
+				agent_id: 'agent-1',
+				status: 'running',
+				metadata: { cpu: 85 }
+			});
+
+			const agent = agentStore.agents.find((a: unknown) => (a as { id: string }).id === 'agent-1');
+			expect((agent as { metadata?: Record<string, unknown> }).metadata?.cpu).toBe(85);
+		});
+
+		it('does nothing for unknown agent', () => {
+			agentStore.agents = [...mockAgents];
+
+			agentStore.handleStatusChange({
+				agent_id: 'unknown-agent',
+				status: 'running'
+			});
+
+			expect(agentStore.agents).toHaveLength(2);
+		});
+	});
+
+	describe('handleCycleStart', () => {
+		it('updates cycle info on agent', async () => {
+			agentStore.agents = [...mockAgents];
+
+			agentStore.handleCycleStart({
+				agent_id: 'agent-1',
+				cycle_id: 'cycle-123',
+				started_at: '2024-01-15T10:00:00Z'
+			});
+
+			const agent = agentStore.agents.find((a: unknown) => (a as { id: string }).id === 'agent-1');
+			expect((agent as { current_cycle_id?: string }).current_cycle_id).toBe('cycle-123');
+			expect((agent as { cycle_started_at?: string }).cycle_started_at).toBe('2024-01-15T10:00:00Z');
+		});
+	});
+
+	describe('handleCycleComplete', () => {
+		it('updates cycle completion on agent', async () => {
+			agentStore.agents = [...mockAgents];
+
+			agentStore.handleCycleComplete({
+				agent_id: 'agent-1',
+				cycle_id: 'cycle-123',
+				completed_at: '2024-01-15T10:05:00Z',
+				output: { result: 'success' }
+			});
+
+			const agent = agentStore.agents.find((a: unknown) => (a as { id: string }).id === 'agent-1');
+			expect((agent as { last_cycle_id?: string }).last_cycle_id).toBe('cycle-123');
+			expect((agent as { cycle_completed_at?: string }).cycle_completed_at).toBe('2024-01-15T10:05:00Z');
+			expect((agent as { last_cycle_output?: unknown }).last_cycle_output).toEqual({ result: 'success' });
+		});
+	});
+
+	describe('destroy', () => {
+		it('cleans up all handlers and unsubscribes from topics', async () => {
+			const { apiClient } = await import('$lib/api/client');
+			const { realtimeManager } = await import('$lib/realtime/manager.svelte');
+
+			// Set up mock BEFORE calling init
+			const unsubscribeFn = vi.fn();
+			vi.mocked(realtimeManager.on).mockReturnValue(unsubscribeFn);
+			vi.mocked(apiClient.request).mockResolvedValue(mockAgents);
+
+			agentStore.agents = [...mockAgents];
+			await agentStore.init();
+
+			agentStore.destroy();
+
+			expect(unsubscribeFn).toHaveBeenCalled();
+			expect(realtimeManager.unsubscribe).toHaveBeenCalledWith([
+				'agent:agent-1:status',
+				'agent:agent-2:status'
+			]);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Implements Slice 8: Agent Store Integration — real-time agent status updates for the real-time UI unit.

## Changes

### Frontend
- `src/lib/stores/agents.svelte.ts` — `AgentStore` class with reactive agents list, REST init + real-time subscription, event handlers for status/cycle events
- `src/lib/api/types.ts` — Added `Agent` and `AgentsListResponse` interfaces
- `src/lib/api/client.ts` — Added `listAgents()` and `getAgent(id)` methods
- `src/routes/(app)/+page.svelte` — Initializes `agentStore` on mount, cleans up on unmount
- `src/lib/realtime/manager.svelte.ts` — Added `refreshAuth(token)` for token refresh without reconnect, event routing by `event_type`
- `src/lib/realtime/connection.svelte.ts` — Added `sendAuth(token)` method
- `src/lib/stores/auth.svelte.ts` — Wired `realtimeManager.refreshAuth()` after token refresh

### Tests
- `src/test/stores/agents.svelte.test.ts` — 9 tests (init, handlers, status change, cycle events, destroy)

## Validation
- `make test` — 310 tests pass
- `svelte-check` — 0 errors, 0 warnings

## Related
- Implements Slice 8 from implementation_plan.md
- Depends on Slices 5-6 (RealtimeManager, polling fallback)