### PR TITLE
[unit: realtime-ui] Slice 10: System Health & Usage Real-time Topics

### DIFF
--- a/backend/internal/api/realtime/integration_test.go
+++ b/backend/internal/api/realtime/integration_test.go
@@ -1,0 +1,216 @@
+package realtime
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+	"go.uber.org/zap"
+
+	"ace/internal/api/model"
+	"ace/internal/messaging"
+)
+
+// TestIntegration_SystemHealthNATStoWebSocket verifies that publishing to NATS
+// ace.system.health.ok results in an event arriving on a subscribed WebSocket client.
+func TestIntegration_SystemHealthNATStoWebSocket(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	meter := noop.NewMeterProvider().Meter("test")
+	h := NewHub(testNATSConn, logger, meter)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		require.NoError(t, err)
+		c := NewClient(conn, "user1", model.RoleUser, h)
+		h.Register(c)
+		ctx := r.Context()
+		go c.writePump(ctx)
+		c.readPump(ctx)
+	}))
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.CloseNow() })
+
+	// Consume auth_ok.
+	var authMsg ServerMessage
+	require.NoError(t, wsjson.Read(context.Background(), conn, &authMsg))
+	assert.Equal(t, ServerMessageAuthOk, authMsg.Type)
+
+	// Subscribe to system:health topic.
+	require.NoError(t, wsjson.Write(context.Background(), conn, ClientMessage{
+		Type:   ClientMessageSubscribe,
+		Topics: []string{"system:health"},
+	}))
+
+	var subMsg ServerMessage
+	require.NoError(t, wsjson.Read(context.Background(), conn, &subMsg))
+	assert.Equal(t, ServerMessageSubscribed, subMsg.Type)
+	assert.Contains(t, subMsg.Topics, "system:health")
+
+	// Publish a health event to NATS with proper envelope headers.
+	healthData := map[string]interface{}{
+		"status": "ok",
+		"checks": map[string]interface{}{
+			"database": map[string]interface{}{"status": "healthy"},
+			"nats":     map[string]interface{}{"status": "healthy"},
+			"cache":    map[string]interface{}{"status": "healthy"},
+		},
+	}
+	payload, err := json.Marshal(healthData)
+	require.NoError(t, err)
+
+	msg := nats.NewMsg("ace.system.health.ok")
+	msg.Data = payload
+	env := messaging.NewEnvelope("", "", "", "test-service")
+	messaging.SetHeaders(msg, env)
+	err = testNATSConn.PublishMsg(msg)
+	require.NoError(t, err)
+
+	// Read the event from WebSocket.
+	var eventMsg ServerMessage
+	require.NoError(t, wsjson.Read(context.Background(), conn, &eventMsg))
+	assert.Equal(t, ServerMessageEvent, eventMsg.Type)
+	assert.Equal(t, "system:health", eventMsg.Topic)
+	assert.NotZero(t, eventMsg.Seq)
+
+	// Verify the data matches what we published (Data contains EventData wrapper).
+	var eventData EventData
+	err = json.Unmarshal(eventMsg.Data, &eventData)
+	require.NoError(t, err)
+	assert.Equal(t, "event", eventData.EventType)
+
+	var received map[string]interface{}
+	err = json.Unmarshal(eventData.Data, &received)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", received["status"])
+
+	h.Close()
+}
+
+// TestIntegration_UsageNATStoWebSocket verifies that publishing to NATS
+// ace.usage.{id}.cost results in an event arriving on the subscribed WebSocket client.
+func TestIntegration_UsageNATStoWebSocket(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	meter := noop.NewMeterProvider().Meter("test")
+	h := NewHub(testNATSConn, logger, meter)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		require.NoError(t, err)
+		c := NewClient(conn, "user1", model.RoleUser, h)
+		h.Register(c)
+		ctx := r.Context()
+		go c.writePump(ctx)
+		c.readPump(ctx)
+	}))
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.CloseNow() })
+
+	// Consume auth_ok.
+	var authMsg ServerMessage
+	require.NoError(t, wsjson.Read(context.Background(), conn, &authMsg))
+	assert.Equal(t, ServerMessageAuthOk, authMsg.Type)
+
+	// Subscribe to usage:user1 topic.
+	require.NoError(t, wsjson.Write(context.Background(), conn, ClientMessage{
+		Type:   ClientMessageSubscribe,
+		Topics: []string{"usage:user1"},
+	}))
+
+	var subMsg ServerMessage
+	require.NoError(t, wsjson.Read(context.Background(), conn, &subMsg))
+	assert.Equal(t, ServerMessageSubscribed, subMsg.Type)
+	assert.Contains(t, subMsg.Topics, "usage:user1")
+
+	// Publish a usage cost event to NATS with proper envelope headers.
+	usageData := map[string]interface{}{
+		"event_type": "usage.cost",
+		"agent_id":   "agent-123",
+		"cost_usd":   0.05,
+		"tokens":     1500,
+	}
+	payload, err := json.Marshal(usageData)
+	require.NoError(t, err)
+
+	msg := nats.NewMsg("ace.usage.user1.cost")
+	msg.Data = payload
+	env := messaging.NewEnvelope("", "", "", "test-service")
+	messaging.SetHeaders(msg, env)
+	err = testNATSConn.PublishMsg(msg)
+	require.NoError(t, err)
+
+	// Read the event from WebSocket.
+	var eventMsg ServerMessage
+	require.NoError(t, wsjson.Read(context.Background(), conn, &eventMsg))
+	assert.Equal(t, ServerMessageEvent, eventMsg.Type)
+	assert.Equal(t, "usage:user1", eventMsg.Topic)
+	assert.NotZero(t, eventMsg.Seq)
+
+	// Verify the data contains the cost info (Data contains EventData wrapper).
+	var eventData EventData
+	err = json.Unmarshal(eventMsg.Data, &eventData)
+	require.NoError(t, err)
+	assert.Equal(t, "event", eventData.EventType)
+
+	var received map[string]interface{}
+	err = json.Unmarshal(eventData.Data, &received)
+	require.NoError(t, err)
+	assert.Equal(t, "usage.cost", received["event_type"])
+	assert.Equal(t, 0.05, received["cost_usd"])
+
+	h.Close()
+}
+
+// TestIntegration_DispatchNATSEvent_SequencesEvents verifies that dispatchNATSEvent
+// correctly sequences events even when called rapidly.
+func TestIntegration_DispatchNATSEvent_SequencesEvents(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	meter := noop.NewMeterProvider().Meter("test")
+	h := NewHub(testNATSConn, logger, meter)
+
+	// Direct client setup without WebSocket for unit-level test.
+	c := &Client{
+		id:          "seq-test-client",
+		userID:      "user1",
+		role:        model.RoleUser,
+		topics:      map[string]struct{}{"system:health": {}},
+		send:        make(chan []byte, 128),
+		connectedAt: time.Now(),
+		hub:         h,
+	}
+	h.mu.Lock()
+	h.clients["user1"] = append(h.clients["user1"], c)
+	h.mu.Unlock()
+
+	// Dispatch three events rapidly.
+	for i := 1; i <= 3; i++ {
+		h.dispatchNATSEvent("system:health", []byte(`{"seq":`+string(rune('0'+i))+`}`))
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Verify sequencing via buffer.
+	seq1 := h.buffer.GetLastSeq("system:health")
+	assert.Equal(t, uint64(3), seq1)
+
+	h.mu.Lock()
+	delete(h.clients, "user1")
+	h.mu.Unlock()
+	h.Close()
+}

--- a/frontend/src/lib/components/telemetry/HealthCards.svelte
+++ b/frontend/src/lib/components/telemetry/HealthCards.svelte
@@ -2,6 +2,8 @@
 	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card';
 	import Skeleton from '$lib/components/ui/skeleton/skeleton.svelte';
 	import { Database, Zap, HardDrive } from 'lucide-svelte';
+	import { realtimeManager } from '$lib/realtime/manager.svelte';
+	import { getHealth } from '$lib/api/telemetry';
 	import type { TelemetryHealthResponse, HealthStatus } from '$lib/api/types';
 
 	type Props = {
@@ -11,6 +13,25 @@
 	};
 
 	let { health, loading = false, error = null }: Props = $props();
+
+	// Subscribe to system:health topic for real-time updates
+	$effect(() => {
+		realtimeManager.subscribe(['system:health']);
+
+		const unsub = realtimeManager.on('system:health', (data) => {
+			// Update health state when real-time event arrives
+			const eventData = data as { status?: string; checks?: Record<string, { status: string }> };
+			health = {
+				status: (eventData.status ?? 'ok') as HealthStatus,
+				checks: eventData.checks as TelemetryHealthResponse['checks']
+			};
+		});
+
+		return () => {
+			unsub();
+			realtimeManager.unsubscribe(['system:health']);
+		};
+	});
 
 	function getStatusColor(status: HealthStatus): string {
 		switch (status) {

--- a/frontend/src/lib/realtime/manager.svelte.ts
+++ b/frontend/src/lib/realtime/manager.svelte.ts
@@ -41,7 +41,7 @@ class RealtimeManager {
 		const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
 		const url = `${protocol}//${location.host}/api/ws`;
 
-		this.status = 'connecting';
+		this.setStatus('connecting');
 		const conn = new WebSocketConnection();
 		this.connection = conn;
 
@@ -50,7 +50,7 @@ class RealtimeManager {
 		conn
 			.connect(url, this.currentToken)
 			.then(() => {
-				this.status = 'connected';
+				this.setStatus('connected');
 				this.reconnectManager.reset();
 				this.reconnectAttempts = 0;
 				this.stopPollingReconnectTimer();
@@ -75,7 +75,7 @@ class RealtimeManager {
 		const attempt = this.reconnectManager.incrementAttempt();
 
 		if (this.reconnectManager.shouldRetry(attempt)) {
-			this.status = 'reconnecting';
+			this.setStatus('reconnecting');
 			this.reconnectAttempts = attempt;
 			const delay = this.reconnectManager.getDelay(attempt);
 
@@ -83,7 +83,7 @@ class RealtimeManager {
 				this.doConnect();
 			}, delay);
 		} else {
-			this.status = 'polling';
+			this.setStatus('polling');
 			this.startPollingFallback();
 			this.startPollingReconnectTimer();
 		}
@@ -116,7 +116,7 @@ class RealtimeManager {
 	private attemptWebSocketReconnect(): void {
 		if (this.status !== 'polling') return;
 
-		this.status = 'connecting';
+		this.setStatus('connecting');
 		const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
 		const url = `${protocol}//${location.host}/api/ws`;
 
@@ -127,7 +127,7 @@ class RealtimeManager {
 		conn
 			.connect(url, this.currentToken)
 			.then(() => {
-				this.status = 'connected';
+				this.setStatus('connected');
 				this.reconnectManager.reset();
 				this.reconnectAttempts = 0;
 				this.stopPollingReconnectTimer();
@@ -225,7 +225,7 @@ class RealtimeManager {
 		this.pollingClient.stop();
 		this.connection?.close();
 		this.connection = null;
-		this.status = 'disconnected';
+		this.setStatus('disconnected');
 		this.sendQueue = [];
 	}
 
@@ -296,6 +296,23 @@ class RealtimeManager {
 				for (const h of typeHandlers) {
 					h(eventPayload.data ?? evt.data);
 				}
+			}
+		}
+	}
+
+	// setStatus updates the connection status and emits change events.
+	private setStatus(status: ConnectionStatus): void {
+		const prev = this.status;
+		this.status = status;
+		// Emit status change event for external listeners (e.g., notification store)
+		this.emitStatusChange(status, prev);
+	}
+
+	private emitStatusChange(status: ConnectionStatus, previous: ConnectionStatus): void {
+		const handlers = this.handlers.get('connection_status');
+		if (handlers) {
+			for (const h of handlers) {
+				h({ status, previous });
 			}
 		}
 	}

--- a/frontend/src/lib/stores/notifications.svelte.ts
+++ b/frontend/src/lib/stores/notifications.svelte.ts
@@ -1,3 +1,6 @@
+import { realtimeManager } from '$lib/realtime/manager.svelte';
+import type { ConnectionStatus } from '$lib/realtime/types';
+
 export interface Toast {
 	id: string;
 	variant: 'success' | 'error' | 'warning' | 'info';
@@ -10,12 +13,19 @@ export interface Toast {
 class NotificationStore {
 	toasts = $state<Toast[]>([]);
 
+	private previousStatus: ConnectionStatus = 'disconnected';
+	private statusUnsubscribe: (() => void) | null = null;
+	private statusListenerInitialized = false;
+
 	add(
 		title: string,
 		variant: Toast['variant'] = 'info',
 		description?: string,
 		duration: number = 5000
 	): string {
+		// Lazy initialization of status listener on first use
+		this.initStatusListener();
+
 		const id = crypto.randomUUID();
 		const toast: Toast = {
 			id,
@@ -32,6 +42,37 @@ class NotificationStore {
 		}
 
 		return id;
+	}
+
+	private initStatusListener(): void {
+		if (this.statusListenerInitialized) return;
+		this.statusListenerInitialized = true;
+
+		// Listen for connection status changes from realtimeManager
+		realtimeManager.on('connection_status', (data) => {
+			const { status, previous } = data as { status: ConnectionStatus; previous: ConnectionStatus };
+			this.handleStatusChange(status, previous);
+		});
+	}
+
+	private handleStatusChange(status: ConnectionStatus, eventPrevious: ConnectionStatus): void {
+		// When disconnected, show warning (but not if already disconnected)
+		if (status === 'disconnected' && eventPrevious !== 'disconnected') {
+			this.warning('Connection lost. Reconnecting...');
+		}
+
+		// When connected from polling or disconnected, show success
+		if (status === 'connected' && (eventPrevious === 'polling' || eventPrevious === 'disconnected')) {
+			this.success('Connected');
+		}
+
+		// When switching to polling, show info
+		if (status === 'polling' && eventPrevious !== 'polling') {
+			this.info('Using polling mode');
+		}
+
+		// Update stored previous status
+		this.previousStatus = status;
 	}
 
 	dismiss(id: string): void {

--- a/frontend/src/lib/stores/usage.svelte.ts
+++ b/frontend/src/lib/stores/usage.svelte.ts
@@ -1,0 +1,87 @@
+import { realtimeManager } from '$lib/realtime/manager.svelte';
+import { apiClient } from '$lib/api/client';
+import type { UsageEvent } from '$lib/api/types';
+
+export interface UsageCostData {
+	event_type: string;
+	agent_id: string;
+	session_id: string;
+	cost_usd: number;
+	input_tokens?: number;
+	output_tokens?: number;
+	timestamp: string;
+}
+
+class UsageStore {
+	usageEvents = $state<UsageEvent[]>([]);
+	loading = $state(false);
+	error = $state<string | null>(null);
+
+	private unsubscribers: (() => void)[] = [];
+	private userId: string | null = null;
+
+	init(userId: string): Promise<void> {
+		this.loading = true;
+		this.error = null;
+		this.userId = userId;
+
+		return this.fetchUsageEvents()
+			.then(() => this.subscribeToUsageTopic())
+			.finally(() => {
+				this.loading = false;
+			});
+	}
+
+	private async fetchUsageEvents(): Promise<void> {
+		try {
+			const response = await apiClient.request<{ events: UsageEvent[] }>({
+				method: 'GET',
+				path: `/telemetry/usage?limit=50`
+			});
+			this.usageEvents = response.events ?? [];
+		} catch (err) {
+			this.error = err instanceof Error ? err.message : 'Failed to fetch usage events';
+		}
+	}
+
+	private subscribeToUsageTopic(): void {
+		if (!this.userId) return;
+
+		const topic = `usage:${this.userId}`;
+		realtimeManager.subscribe([topic]);
+
+		const unsubCost = realtimeManager.on('usage.cost', (data) => {
+			this.handleUsageCost(data as UsageCostData);
+		});
+		this.unsubscribers.push(unsubCost);
+	}
+
+	handleUsageCost(data: UsageCostData): void {
+		// Prepend new cost event to the list
+		const event: UsageEvent = {
+			id: crypto.randomUUID(),
+			agent_id: data.agent_id,
+			session_id: data.session_id,
+			event_type: data.event_type,
+			cost_usd: data.cost_usd,
+			input_tokens: data.input_tokens,
+			output_tokens: data.output_tokens,
+			timestamp: data.timestamp
+		};
+		this.usageEvents = [event, ...this.usageEvents].slice(0, 100);
+	}
+
+	destroy(): void {
+		for (const unsub of this.unsubscribers) {
+			unsub();
+		}
+		this.unsubscribers = [];
+
+		if (this.userId) {
+			realtimeManager.unsubscribe([`usage:${this.userId}`]);
+		}
+		this.userId = null;
+	}
+}
+
+export const usageStore = new UsageStore();

--- a/frontend/src/test/stores/notifications.svelte.test.ts
+++ b/frontend/src/test/stores/notifications.svelte.test.ts
@@ -3,6 +3,20 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // We need to test the actual module, so we import it directly
 // But we need to reset the module between tests to avoid state leakage
 
+// Mock realtimeManager before importing the module
+let statusChangeHandler: ((data: { status: string; previous: string }) => void) | null = null;
+
+vi.mock('$lib/realtime/manager.svelte', () => ({
+	realtimeManager: {
+		on: vi.fn((eventType: string, handler: (data: unknown) => void) => {
+			if (eventType === 'connection_status') {
+				statusChangeHandler = handler as (data: { status: string; previous: string }) => void;
+			}
+			return () => {};
+		})
+	}
+}));
+
 describe('NotificationStore', () => {
 	let notificationStore: {
 		toasts: unknown[];
@@ -17,6 +31,10 @@ describe('NotificationStore', () => {
 	beforeEach(async () => {
 		vi.clearAllMocks();
 		vi.useFakeTimers();
+		statusChangeHandler = null;
+
+		// Reset module cache to get fresh import
+		vi.resetModules();
 
 		// Clear module cache to get fresh instance
 		const mod = await import('$lib/stores/notifications.svelte');
@@ -146,6 +164,81 @@ describe('NotificationStore', () => {
 			const toast = notificationStore.toasts[0] as Record<string, unknown>;
 			expect(toast.variant).toBe('info');
 			expect(toast.title).toBe('Info');
+		});
+	});
+
+	describe('connection status notifications', () => {
+		it('shows warning when status transitions to disconnected', () => {
+			// Trigger the status listener setup by calling add, then clear the toast
+			notificationStore.add('Init');
+			notificationStore.toasts = [];
+
+			expect(statusChangeHandler).not.toBeNull();
+
+			// Simulate disconnected from connected
+			statusChangeHandler!({ status: 'disconnected', previous: 'connected' });
+
+			expect(notificationStore.toasts).toHaveLength(1);
+			const toast = notificationStore.toasts[0] as Record<string, unknown>;
+			expect(toast.variant).toBe('warning');
+			expect(toast.title).toBe('Connection lost. Reconnecting...');
+		});
+
+		it('shows success when status transitions to connected from disconnected', () => {
+			notificationStore.add('Init');
+			notificationStore.toasts = [];
+
+			expect(statusChangeHandler).not.toBeNull();
+
+			// Simulate connected from disconnected
+			statusChangeHandler!({ status: 'connected', previous: 'disconnected' });
+
+			expect(notificationStore.toasts).toHaveLength(1);
+			const toast = notificationStore.toasts[0] as Record<string, unknown>;
+			expect(toast.variant).toBe('success');
+			expect(toast.title).toBe('Connected');
+		});
+
+		it('shows success when status transitions to connected from polling', () => {
+			notificationStore.add('Init');
+			notificationStore.toasts = [];
+
+			expect(statusChangeHandler).not.toBeNull();
+
+			// Simulate connected from polling
+			statusChangeHandler!({ status: 'connected', previous: 'polling' });
+
+			expect(notificationStore.toasts).toHaveLength(1);
+			const toast = notificationStore.toasts[0] as Record<string, unknown>;
+			expect(toast.variant).toBe('success');
+			expect(toast.title).toBe('Connected');
+		});
+
+		it('shows info when status transitions to polling', () => {
+			notificationStore.add('Init');
+			notificationStore.toasts = [];
+
+			expect(statusChangeHandler).not.toBeNull();
+
+			// Simulate polling
+			statusChangeHandler!({ status: 'polling', previous: 'connected' });
+
+			expect(notificationStore.toasts).toHaveLength(1);
+			const toast = notificationStore.toasts[0] as Record<string, unknown>;
+			expect(toast.variant).toBe('info');
+			expect(toast.title).toBe('Using polling mode');
+		});
+
+		it('does not show notification when status stays the same', () => {
+			notificationStore.add('Init');
+			notificationStore.toasts = [];
+
+			expect(statusChangeHandler).not.toBeNull();
+
+			// Simulate disconnected from disconnected (no change)
+			statusChangeHandler!({ status: 'disconnected', previous: 'disconnected' });
+
+			expect(notificationStore.toasts).toHaveLength(0);
 		});
 	});
 });

--- a/frontend/src/test/stores/usage.svelte.test.ts
+++ b/frontend/src/test/stores/usage.svelte.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/api/client', () => ({
+	apiClient: {
+		request: vi.fn()
+	}
+}));
+
+vi.mock('$lib/realtime/manager.svelte', () => ({
+	realtimeManager: {
+		subscribe: vi.fn(),
+		unsubscribe: vi.fn(),
+		on: vi.fn().mockReturnValue(() => {})
+	}
+}));
+
+describe('UsageStore', () => {
+	let usageStore: {
+		usageEvents: unknown[];
+		loading: unknown;
+		error: unknown;
+		init: (userId: string) => Promise<void>;
+		destroy: () => void;
+		handleUsageCost: (data: { event_type: string; agent_id: string; session_id: string; cost_usd: number; input_tokens?: number; output_tokens?: number; timestamp: string }) => void;
+	};
+
+	const mockUsageResponse = {
+		events: [
+			{
+				id: 'event-1',
+				agent_id: 'agent-1',
+				session_id: 'session-1',
+				event_type: 'usage.cost',
+				cost_usd: 0.01,
+				input_tokens: 100,
+				output_tokens: 200,
+				timestamp: '2024-01-15T10:00:00Z'
+			},
+			{
+				id: 'event-2',
+				agent_id: 'agent-2',
+				session_id: 'session-2',
+				event_type: 'usage.cost',
+				cost_usd: 0.02,
+				input_tokens: 150,
+				output_tokens: 300,
+				timestamp: '2024-01-15T11:00:00Z'
+			}
+		]
+	};
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		const mod = await import('$lib/stores/usage.svelte');
+		usageStore = mod.usageStore as unknown as typeof usageStore;
+		usageStore.usageEvents = [];
+		usageStore.loading = false;
+		usageStore.error = null;
+	});
+
+	describe('init', () => {
+		it('fetches usage events via REST and subscribes to topic', async () => {
+			const { apiClient } = await import('$lib/api/client');
+			const { realtimeManager } = await import('$lib/realtime/manager.svelte');
+
+			vi.mocked(apiClient.request).mockResolvedValue(mockUsageResponse);
+
+			await usageStore.init('user1');
+
+			expect(apiClient.request).toHaveBeenCalledWith({
+				method: 'GET',
+				path: '/telemetry/usage?limit=50'
+			});
+			expect(realtimeManager.subscribe).toHaveBeenCalledWith(['usage:user1']);
+			expect(usageStore.usageEvents).toEqual(mockUsageResponse.events);
+			expect(usageStore.loading).toBe(false);
+		});
+
+		it('sets error on fetch failure', async () => {
+			const { apiClient } = await import('$lib/api/client');
+
+			vi.mocked(apiClient.request).mockRejectedValue(new Error('Network error'));
+
+			await usageStore.init('user1');
+
+			expect(usageStore.error).toBe('Network error');
+			expect(usageStore.loading).toBe(false);
+		});
+
+		it('registers handler for usage.cost events', async () => {
+			const { apiClient } = await import('$lib/api/client');
+			const { realtimeManager } = await import('$lib/realtime/manager.svelte');
+
+			vi.mocked(apiClient.request).mockResolvedValue(mockUsageResponse);
+
+			await usageStore.init('user1');
+
+			expect(realtimeManager.on).toHaveBeenCalledWith(
+				'usage.cost',
+				expect.any(Function)
+			);
+		});
+	});
+
+	describe('handleUsageCost', () => {
+		it('prepends new cost event to the list', () => {
+			usageStore.usageEvents = [...mockUsageResponse.events];
+
+			usageStore.handleUsageCost({
+				event_type: 'usage.cost',
+				agent_id: 'agent-3',
+				session_id: 'session-3',
+				cost_usd: 0.05,
+				input_tokens: 500,
+				output_tokens: 1000,
+				timestamp: '2024-01-15T12:00:00Z'
+			});
+
+			expect(usageStore.usageEvents).toHaveLength(3);
+			expect((usageStore.usageEvents[0] as { agent_id: string }).agent_id).toBe('agent-3');
+		});
+
+		it('limits events to 100', () => {
+			// Create 100 existing events
+			const manyEvents = Array.from({ length: 100 }, (_, i) => ({
+				id: `event-${i}`,
+				agent_id: `agent-${i}`,
+				session_id: `session-${i}`,
+				event_type: 'usage.cost',
+				cost_usd: 0.01,
+				timestamp: '2024-01-15T10:00:00Z'
+			}));
+			usageStore.usageEvents = manyEvents;
+
+			usageStore.handleUsageCost({
+				event_type: 'usage.cost',
+				agent_id: 'agent-new',
+				session_id: 'session-new',
+				cost_usd: 0.05,
+				timestamp: '2024-01-15T12:00:00Z'
+			});
+
+			expect(usageStore.usageEvents).toHaveLength(100);
+		});
+	});
+
+	describe('destroy', () => {
+		it('cleans up handlers and unsubscribes from topics', async () => {
+			const { realtimeManager } = await import('$lib/realtime/manager.svelte');
+
+			const unsubscribeFn = vi.fn();
+			vi.mocked(realtimeManager.on).mockReturnValue(unsubscribeFn);
+
+			await usageStore.init('user1');
+			usageStore.destroy();
+
+			expect(unsubscribeFn).toHaveBeenCalled();
+			expect(realtimeManager.unsubscribe).toHaveBeenCalledWith(['usage:user1']);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Implements Slice 10: System Health & Usage Real-time Topics — end-to-end demo of NATS→WebSocket→UI event flow.

## Changes

### Backend
- `internal/api/realtime/integration_test.go` — Integration test: publish to NATS `ace.system.health.ok`, verify WebSocket client receives event with correct topic and seq

### Frontend
- `src/lib/stores/usage.svelte.ts` — `UsageStore` class with reactive usage events, REST init + real-time subscription to `usage:{userId}` topic
- `src/lib/stores/notifications.svelte.ts` — Added real-time connection status toasts (disconnected/connected/polling transitions)
- `src/lib/realtime/manager.svelte.ts` — Added `setStatus()` method emitting `connection_status` events for listeners
- `src/lib/components/telemetry/HealthCards.svelte` — Subscribed to `system:health` topic for real-time health updates

### Tests
- `src/test/stores/usage.svelte.test.ts` — 6 tests (init, event handling, destroy)
- `src/test/stores/notifications.svelte.test.ts` — 5 new tests (connection status toasts)

## Validation
- `make test` — 321 tests pass
- `svelte-check` — 0 errors, 0 warnings

## Related
- Implements Slice 10 from implementation_plan.md
- Depends on Slices 4-8 (routes, manager, polling, store pattern)