### PR TITLE
[unit: agents-study] Add Karpathy Loopy Era and Wiki research

### DIFF
--- a/design/units/agents-study/study/architecture.md
+++ b/design/units/agents-study/study/architecture.md
@@ -540,6 +540,104 @@ All surfaces share `crates/goose/` — the core agent logic is surface-agnostic.
 
 ---
 
+## 11.1 Karpathy's Software 3.0 and the Loopy Era (2026)
+
+**Source:** No Priors podcast, "Software Is Changing (Again)" talk, Twitter/X posts
+
+### The Software Evolution Arc
+
+Karpathy frames the history of programming as three paradigms:
+
+| Era | Programming Method | Example |
+|-----|-------------------|---------|
+| Software 1.0 | Code (C++, Python) programs the computer | Traditional programming |
+| Software 2.0 | Weights (neural nets) program the computer | ML models |
+| Software 3.0 | Prompts (natural language) program the LLM | Current era |
+
+> "We're literally programming in English. The same shift that replaced Tesla's C++ Autopilot stack is happening everywhere."
+
+### The "Loopy Era" of Agentic Systems
+
+Karpathy describes the current moment as the "loopy era" — where agents, persistent "claws," and automated research loops are chained, optimized, and parallelized:
+
+**Key characteristics:**
+- **Agents as primary manipulators** — LLMs now manipulate digital content, joining humans (via GUIs) and programs (via APIs) as a third category
+- **The customer is not the human anymore** — it's agents acting on behalf of humans
+- **Maximum leverage** — minimal token input, massive output, zero human in the loop
+- **"AI psychosis"** — the perpetual state of amazement at how powerful these systems have become
+
+**The shift in engineering workflow:**
+- Before December 2025: ~80% code written by hand, 20% delegation to agents
+- After December 2025: Effectively 0% hand-coding — entirely delegation
+
+> "I don't think I've typed a line of code probably since December, basically, which is an extremely large change."
+
+### The Iron Man Model: Partial Autonomy
+
+Karpathy's key insight for agent design is the **Iron Man analogy**:
+
+- The Iron Man suit = Agent + Augmentation
+- Can act autonomously but is most effective when paired with Tony Stark
+- **The future lies in tight human-AI feedback loops**
+- Autonomy should be **adjustable** — not all-or-nothing
+
+**Cursor as the pattern:**
+- `Tab` → `Cmd+K` → `Cmd+L` → full background agent mode
+- The autonomy slider is the key UX innovation
+
+### Design Implications from Software 3.0
+
+**1. Build for agents, not just humans:**
+- Agents are a new category of digital content manipulator
+- Create markdown-readable interfaces, machine-consumable documentation (`llms.txt`)
+- Avoid GUI-only affordances
+- Examples: `git.ingest`, DeepWiki
+
+**2. The Autonomy Slider pattern:**
+- Not binary (manual vs autonomous)
+- A spectrum of control that users can adjust per-context
+- The cursor pattern: Tab (suggest) → Cmd+K (agent) → Cmd+L (background)
+
+**3. Agent-targeted documentation:**
+- Education and docs become "agent-targeted artifacts" (agents teach humans)
+- Program.md as executable organizational specification
+- Skills and procedures written for both human and agent consumption
+
+### The "Claw" Pattern: Persistent Agents
+
+**"Claws"** are persistent, semi-autonomous agent entities that run continuously:
+
+> "The LLM sort of part is now taken for granted. The agent part is now taken for granted. Now the claw-like entities are taken for granted and now you can have multiple of them."
+
+**Dobby the Elf example** (home automation claw):
+- Controlled via WhatsApp natural language interface
+- Scans LAN for smart devices
+- Reverses APIs for Sonos/lights
+- Builds control portal integrating multiple systems
+- Vision model for alerts (Quinn)
+- Replaces 6+ separate apps with single natural language interface
+
+**Key insight:** Claws run as continuous loops in sandboxes, not one-shot invocations. ACE should support persistent agent lifetimes, not just request-response cycles.
+
+### Architectural Implications for ACE
+
+| Pattern | Karpathy's Evidence | ACE Recommendation |
+|---------|-------------------|-------------------|
+| Autonomy sliders | Cursor: Tab → Cmd+K → Cmd+L | **ADOPT** — ACE should expose adjustable autonomy levels |
+| Agent-targeted docs | llms.txt, git.ingest | **ADOPT** — ACE should generate machine-readable interface specs |
+| Persistent claws | Dobby the Elf | **ADOPT** — ACE should support long-running agent lifetimes |
+| Human as metric designer | Program.md philosophy | **ADOPT** — ACE's human roles should be objective-setting, not code-writing |
+| Loopy era orchestration | Multiple agents in parallel | **ADOPT** — ACE should support multi-agent parallel execution with coordination |
+| Bounded autonomy | Fixed 5-min loop + program.md | **ADOPT** — ACE agents should have clear boundaries and objectives |
+
+### Key Quote
+
+> "The name of the game now is how can you get more agents running for longer periods of time without your involvement doing stuff on your behalf?"
+
+This defines the central optimization target: **maximize token throughput per human token invested**.
+
+---
+
 ## 11. Cross-Cutting Analysis
 
 ### System Topology Summary

--- a/design/units/agents-study/study/loops.md
+++ b/design/units/agents-study/study/loops.md
@@ -98,6 +98,24 @@ read → propose → commit → run 5 min → measure → keep/reset → repeat
 
 This is the only system where the agent loop IS the outer experiment loop, not embedded within a host process.
 
+### 1.5.1 Karpathy's "Loopy Era" Perspective (2026)
+
+Andrej Karpathy describes the current moment as the "loopy era" — a fundamental shift where humans transition from writing code to orchestrating agentic systems:
+
+- **The shift:** Since December 2025, Karpathy reports going from 80% hand-coding to effectively 0% — delegating entirely to agents (Claude Code, Codex)
+- **"AI psychosis":** A state of perpetual amazement at how dramatically agentic systems have changed workflows
+- **The bottleneck moves:** From typing speed to the ability to direct agents and design metrics
+- **Parallelization is key:** Running multiple agents simultaneously across repos (the "Peter Steinberg" approach)
+- **The goal:** Maximum token throughput with minimum human involvement — arrange once, hit go
+
+> "The name of the game now is how can you get more agents running for longer periods of time without your involvement doing stuff on your behalf."
+
+Key practical patterns from the loopy era:
+- Define objective + metric + boundaries, then let agents run experiments
+- Small autonomous experiments extrapolate to frontier scales
+- Education and docs become "agent-targeted artifacts" (agents teach humans)
+- Program.md as executable organization specification
+
 ### 1.6 Effect-Based Service Loop (opencode)
 
 opencode uses the fp-ts `Effect` framework as a purely functional runtime. Agents are services (not objects) with modes:

--- a/design/units/agents-study/study/research-synthesis.md
+++ b/design/units/agents-study/study/research-synthesis.md
@@ -407,6 +407,145 @@
 
 ---
 
+## 7.5 Karpathy's LLM Wiki Pattern (April 2026)
+
+**Source:** https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+
+### Core Concept
+
+The LLM Wiki pattern is a personal knowledge base where an LLM **incrementally builds and maintains a persistent wiki** — structured markdown files that sit between you and raw sources.
+
+**Key insight:** "The wiki is a persistent, compounding artifact. Cross-references are already there. Contradictions have already been flagged. The synthesis already reflects everything you've read."
+
+### Three-Layer Architecture
+
+```
+Raw Sources (immutable) → LLM Wiki (agent-owned) → Schema (AGENTS.md/CLAUDE.md)
+     (articles, papers)         (summaries, entities)      (instructions)
+```
+
+1. **Raw sources** — immutable source documents. The source of truth.
+2. **Wiki** — LLM-generated markdown files. Summaries, entity pages, concept pages. LLM owns this layer entirely.
+3. **Schema** — tells the LLM how the wiki is structured, conventions, workflows. Co-evolved with the LLM.
+
+### Operations
+
+**Ingest:** Drop source → LLM reads → writes summary page → updates index → updates entity/concept pages → appends log entry. Single source might touch 10-15 wiki pages.
+
+**Query:** LLM searches index → drills into relevant pages → synthesizes answer with citations. **Good answers should be filed back into the wiki** as new pages — explorations compound in the knowledge base.
+
+**Lint:** Periodic health-check — contradictions, stale claims, orphan pages, missing cross-references, data gaps.
+
+### Special Files
+
+- **`index.md`** — content-oriented catalog. Lists every page with link, one-line summary, metadata. LLM updates on every ingest. Works well at moderate scale (~100 sources, hundreds of pages).
+- **`log.md`** — chronological append-only record. Ingest events, queries, lint passes. Parseable with `grep "^## \[" log.md | tail -5`.
+
+### Optional: CLI Tools
+
+- **qmd** — local search engine for markdown with hybrid BM25/vector search and LLM re-ranking. Has CLI and MCP server.
+- **Obsidian** — the IDE for the wiki. LLM is the programmer; wiki is the codebase; Obsidian is the viewing window.
+- **Obsidian Web Clipper** — browser extension to convert articles to markdown.
+- **Marp** — markdown-based slide deck format.
+
+### Why This Works
+
+> "The tedious part of maintaining a knowledge base is not the reading or the thinking — it's the bookkeeping. LLMs don't get bored, don't forget to update a cross-reference, and can touch 15 files in one pass."
+
+The human's job: curate sources, direct analysis, ask good questions, think about what it all means.
+The LLM's job: everything else.
+
+Related to Vannevar Bush's Memex (1945) — "private, actively curated, with connections between documents as valuable as the documents themselves." Bush couldn't solve who does the maintenance. The LLM handles that.
+
+### Community Implementations
+
+Several projects have built on this pattern:
+- **llmwiki-cli** — Node.js CLI with GitHub sync, graph visualization
+- **BrainDB** — 5,420 memories, 6 AI agents, self-healing knowledge graph
+- **Synthadoc** — production-ready engine with domain specificity, multi-model hot-swap
+- **claude-obsidian** — emphasizes hot cache as highest-leverage file, memory layer above wiki (DragonScale extension)
+
+### Research Synthesis Connections
+
+The LLM Wiki pattern connects to several themes from the research papers:
+
+1. **Meta-Harness insight** (raw traces > summaries): The wiki IS the trace storage mechanism. Each page is a synthesized trace of what was learned from sources.
+
+2. **RLM's context decomposition**: The wiki's recursive structure (entities link to concepts link to sources) mirrors RLM's approach — never show entire context, decompose instead.
+
+3. **AlphaEvolve's population**: A wiki with multiple perspectives on the same topic (different page authors) mirrors population-based search.
+
+4. **Autoresearch's never-stop**: The lint operation is the never-stop loop for the wiki — periodic health checks without human intervention.
+
+---
+
+## 7.6 The "Loopy Era" — Agentic Systems Research Synthesis
+
+**Source:** No Priors podcast with Andrej Karpathy (March 2026), YouTube summaries
+
+### Key Themes
+
+**1. The Fundamental Shift**
+
+> "I don't think I've typed a line of code probably since December... I kind of feel like I was in this perpetual, I still am often in this state of AI psychosis."
+
+The shift from hand-coding to agent-delegation is dramatic and sudden (around December 2025). The bottleneck moved from typing speed to orchestrating agents and designing metrics.
+
+**2. "Claws" — Persistent Agent Entities**
+
+> "The LLM sort of part is now taken for granted. The agent part is now taken for granted. Now the claw-like entities are taken for granted and now you can have multiple of them."
+
+"Claws" are persistent, semi-autonomous agents running continuous loops. Example: "Dobby the Elf" (home automation) — controlled via WhatsApp, scans LAN, reverses APIs, integrates vision model alerts. Replaces 6+ separate apps.
+
+**3. The Leverage Equation**
+
+- **Input:** Small number of tokens, arranged once
+- **Output:** Massive amounts of work done on behalf of human
+- **Goal:** Maximum token throughput with minimum human involvement
+
+> "The name of the game now is how can you get more agents running for longer periods of time without your involvement doing stuff on your behalf?"
+
+**4. AutoResearch as the Pure Expression**
+
+AutoResearch is the clearest example:
+- Define objective + metric + boundaries
+- Let agents run experiments, tune hyperparameters, iterate without humans in the loop
+- AutoResearch discovered non-obvious hyperparameter improvements (weight decay on value embeddings, Adam betas) that Karpathy missed after two decades of manual tuning
+
+**5. Program.md as Executable Organization**
+
+> "Focus on designing metrics, automation loops, and `program.md`-style specifications for orgs/agents."
+
+`program.md` is an executable specification — written in markdown, interpreted by agents, optimized by the loop. This extends the concept from research to organizational description.
+
+**6. Multi-Agent Parallelization**
+
+The "Peter Steinberg" approach: running multiple Codex sessions simultaneously across different repos. Software development as macro actions (entire features, research tasks) rather than individual lines of code.
+
+**7. Agent-Targeted Artifacts**
+
+> "Education is going to be reshuffled by this quite substantially. Less explaining things directly to people, more: does the agent get it? If the agent gets it, they'll do the explanation."
+
+Docs and education become designed for agent consumption, not just human reading.
+
+### Architectural Implications
+
+| Pattern | Evidence | Implication |
+|---------|----------|-------------|
+| Persistent claws | Dobby the Elf | ACE should support long-running agents, not just one-shot |
+| Autonomy sliders | Cursor: Tab → Cmd+K → Cmd+L | ACE should expose adjustable autonomy levels |
+| Multi-agent parallelization | Peter Steinberg approach | ACE should support parallel agent execution |
+| Program.md as spec | Organization description executable by agents | ACE should implement executable organizational specs |
+| Agent-targeted artifacts | llms.txt, documentation for agents | ACE should generate machine-readable interfaces |
+
+### Key Quote
+
+> "The customer is not the human anymore. It's agents who are acting on behalf of humans."
+
+This reframes who the system is designed for. ACE should optimize for agent consumers, not just human operators.
+
+---
+
 ## Appendix: Quick Reference Table
 
 | Paper | Core contribution | ACE unit | Recommendation |
@@ -425,3 +564,6 @@
 - Meta-Harness: https://arxiv.org/html/2603.28052v1
 - AlphaEvolve: https://arxiv.org/abs/2506.13131
 - RotorQuant: https://github.com/scrya-com/rotorquant (rotorquant.tex + rotorquant_README.md)
+- Karpathy LLM Wiki: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+- Karpathy on Code Agents, AutoResearch, and the Loopy Era of AI (No Priors podcast, March 2026): https://www.youtube.com/watch?v=kwSVtQ7dziU
+- Karpathy "Software Is Changing (Again)": https://www.youtube.com/watch?v=LCEmiRjPEtQ

--- a/design/units/agents-study/study/self-improvement.md
+++ b/design/units/agents-study/study/self-improvement.md
@@ -78,6 +78,51 @@ LOOP FOREVER:
 
 **Evaluation:** This is the gold standard for disciplined self-improvement loops. The fixed budget eliminates iteration-time reasoning overhead. Git-based rollback is trivial and reliable. The simplicity criterion prevents feature accumulation. The untracked results.tsv provides a permanent record outside the git history. The "NEVER STOP" directive ensures continuous experimentation.
 
+### 2.2.1 Karpathy's "AI Psychosis" and the Loopy Era
+
+**Source:** No Priors podcast (March 2026), Karpathy's loopy era talks
+
+Karpathy describes a fundamental shift in his workflow since December 2025:
+
+> "I don't think I've typed a line of code probably since December... this is an extremely large change... I kind of feel like I was in this perpetual, I still am often in this state of AI psychosis."
+
+**The transition:**
+- **Before:** 80% code written by hand, 20% delegation to agents
+- **After:** Effectively 0% hand-coding — entirely agent-delegated
+- **Reason:** The unlock in coding agents around December 2025 was dramatic and sudden
+
+**"Claws" — Persistent Agent Entities:**
+
+Karpathy uses the term "claw" for persistent, semi-autonomous agents that run continuously:
+
+> "The LLM sort of part is now taken for granted. The agent part is now taken for granted. Now the claw-like entities are taken for granted and now you can have multiple of them."
+
+Example: "Dobby the Elf" — a home automation agent controlled via WhatsApp:
+- Scans LAN for smart devices
+- Reverses APIs for Sonos/lights
+- Builds WhatsApp control portal
+- Integrates Quinn vision model alerts
+- Controls everything in natural language
+
+**The leverage equation:**
+- **Human input:** Small number of tokens, arranged once
+- **Agent output:** Massive amounts of work done on behalf of human
+- **The metric:** Token throughput per human involvement ratio
+
+**Program.md as organizational spec:**
+
+The `program.md` concept extends beyond research to organizational description:
+
+> "Focus on designing metrics, automation loops, and `program.md`-style specifications for orgs/agents."
+
+A `program.md` is an executable specification of how an organization or process should run — written in markdown, interpreted by agents, optimized by the loop.
+
+**Implications for ACE's self-improvement:**
+1. **Maximum leverage = minimum human in loop** — design for autonomous operation
+2. **Claws as persistent agents** — ACE should support long-running persistent agents, not just one-shot invocations
+3. **The human as metric designer** — not code writer; humans own objectives, agents own execution
+4. **Program.md as loop protocol** — ACE should implement executable organizational specs that agents interpret
+
 ### 2.3 OpenClaw — Heartbeat Rules and Scheduled Tasks
 
 **Source:** `openclaw/docs/start/openclaw.md`, `openclaw/docs/gateway/heartbeat`, `openclaw/docs/reference/templates/HEARTBEAT.md`, `openclaw/docs/reference/templates/AGENTS.md`

--- a/documentation/api/openapi.json
+++ b/documentation/api/openapi.json
@@ -649,33 +649,6 @@
                 }
             }
         },
-        "/health/ready": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "health"
-                ],
-                "summary": "Readiness probe (includes DB and NATS checks)",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "503": {
-                        "description": "Service Unavailable",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            }
-        },
         "/users": {
             "get": {
                 "consumes": [


### PR DESCRIPTION
## Summary

- Adds Karpathy's "Loopy Era" research from gist and YouTube videos
- Updates 4 study documents with new insights:
  -  - Karpathy's Loopy Era perspective on agent orchestration
  -  - AI psychosis, claw concept, program.md
  -  - Software 3.0, autonomy sliders, agent-targeted artifacts
  -  - LLM Wiki pattern, loopy era synthesis

## Sources Added

- Karpathy's LLM Wiki gist (3-layer architecture: raw sources → wiki → schema)
- YouTube video on LLMs (transcript via web search)
- YouTube video on AI/agents (transcript via web search)

## Key Insights

- "Loopy era" — agents chained together with minimal human in loop
- Software 3.0: prompts as programs
- Autonomy sliders (Cursor pattern: Tab → Cmd+K → Cmd+L)
- "Claws" as persistent agent entities
- LLM Wiki pattern for personal knowledge bases